### PR TITLE
debug.permission Implementation

### DIFF
--- a/addons/SkylliaBank/src/main/java/fr/euphyllia/skylliabank/commands/BankCommand.java
+++ b/addons/SkylliaBank/src/main/java/fr/euphyllia/skylliabank/commands/BankCommand.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.cache.commands.CommandCacheExecution;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import fr.euphyllia.skylliabank.EconomyManager;
 import fr.euphyllia.skylliabank.SkylliaBank;
 import fr.euphyllia.skylliabank.api.BankAccount;
@@ -98,7 +99,7 @@ public class BankCommand implements SubCommandInterface {
      */
     private void handleDeposit(Player player, Island island, String[] args) {
         UUID playerId = player.getUniqueId();
-        if (!player.hasPermission("skyllia.bank.deposit")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.bank.deposit")) {
             ConfigLoader.language.sendMessage(player, "addons.bank.player.no-permission-deposit");
             CommandCacheExecution.removeCommandExec(playerId, "bank");
             return;
@@ -163,7 +164,7 @@ public class BankCommand implements SubCommandInterface {
      */
     private void handleWithdraw(Player player, Island island, String[] args) {
         UUID playerId = player.getUniqueId();
-        if (!player.hasPermission("skyllia.bank.withdraw")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.bank.withdraw")) {
             ConfigLoader.language.sendMessage(player, "addons.bank.player.no-permission-withdraw");
             CommandCacheExecution.removeCommandExec(playerId, "bank");
             return;
@@ -233,7 +234,7 @@ public class BankCommand implements SubCommandInterface {
      */
     private void handleBalance(Player player, Island island) {
         UUID playerId = player.getUniqueId();
-        if (!player.hasPermission("skyllia.bank.balance")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.bank.balance")) {
             ConfigLoader.language.sendMessage(player, "addons.bank.player.no-permission-balance");
             CommandCacheExecution.removeCommandExec(player.getUniqueId(), "bank");
             return;

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/InfoSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/InfoSubCommand.java
@@ -8,6 +8,7 @@ import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -36,7 +37,7 @@ public class InfoSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission(permission())) {
+        if (!PlayerUtils.hasPermission(player, permission())) {
             ConfigLoader.language.sendMessage(player, "island.info.no-permission");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/AccessSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/AccessSubCommand.java
@@ -41,7 +41,7 @@ public class AccessSubCommand implements SubCommandInterface {
             ConfigLoader.language.sendMessage(sender, "island.player.player-only-command");
             return true;
         }
-        if (!player.hasPermission("skyllia.island.command.access")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.access")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
@@ -79,7 +79,7 @@ public class AccessSubCommand implements SubCommandInterface {
 
                                 // NOTE: ton code d'origine check la permission sur "player" (le sender),
                                 // pas sur "playerInIsland". Je garde le même comportement.
-                                if (!player.hasPermission("skyllia.island.command.access.bypass")) return;
+                                if (!PlayerUtils.hasPermission(player, "skyllia.island.command.access.bypass")) return;
 
                                 Bukkit.getAsyncScheduler().runNow(Skyllia.getPlugin(Skyllia.class), t -> {
                                     Players players = island.getMember(playerInIsland.getUniqueId());

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/BanListCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/BanListCommand.java
@@ -5,6 +5,7 @@ import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -24,7 +25,7 @@ public class BanListCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission(permission())) {
+        if (!PlayerUtils.hasPermission(player, permission())) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/BanSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/BanSubCommand.java
@@ -9,6 +9,7 @@ import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
@@ -39,7 +40,7 @@ public class BanSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.ban")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.ban")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
@@ -16,6 +16,7 @@ import fr.euphyllia.skyllia.cache.commands.CommandCacheExecution;
 import fr.euphyllia.skyllia.cache.island.IslandCreationQueue;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.utils.IslandUtils;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,7 +46,7 @@ public class CreateSubCommand implements SubCommandInterface {
                 return;
             }
             CommandCacheExecution.addCommandExecute(playerId, "create");
-            if (!player.hasPermission("skyllia.island.command.create")) {
+            if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create")) {
                 CommandCacheExecution.removeCommandExec(playerId, "create");
                 ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
                 return;
@@ -75,7 +76,7 @@ public class CreateSubCommand implements SubCommandInterface {
                         return;
                     }
 
-                    if (!player.hasPermission("skyllia.island.command.create.%s".formatted(schemKey))) {
+                    if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create.%s".formatted(schemKey))) {
                         ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
                         CommandCacheExecution.removeCommandExec(playerId, "create");
                         return;
@@ -148,13 +149,13 @@ public class CreateSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!sender.hasPermission("skyllia.island.command.create")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
 
         boolean bypass = ConfigLoader.general.isAllowBypassIslandQueue()
-                && player.hasPermission("skyllia.island.bypass.queue");
+                && PlayerUtils.hasPermission(player, "skyllia.island.bypass.queue");
 
         if (bypass) {
             runCreateIsland(Skyllia.getInstance(), player, args);

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DelWarpSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DelWarpSubCommand.java
@@ -8,6 +8,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.cache.commands.CacheCommands;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,7 +47,7 @@ public class DelWarpSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.delwarp")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.delwarp")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
@@ -94,7 +94,7 @@ public class DeleteSubCommand implements SubCommandInterface {
             ConfigLoader.language.sendMessage(sender, "island.player.player-only-command");
             return true;
         }
-        if (!sender.hasPermission("skyllia.island.command.delete")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.delete")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DemoteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DemoteSubCommand.java
@@ -9,6 +9,7 @@ import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,7 +45,7 @@ public class DemoteSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.demote")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.demote")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
@@ -112,7 +113,7 @@ public class DemoteSubCommand implements SubCommandInterface {
     @Override
     public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NotNull String[] args) {
         if (!(sender instanceof Player player)) return Collections.emptyList();
-        if (!player.hasPermission("skyllia.island.command.demote")) return Collections.emptyList();
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.demote")) return Collections.emptyList();
 
         if (args.length == 1) {
             Island island = SkylliaAPI.getIslandByPlayerId(player.getUniqueId());

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/ExpelSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/ExpelSubCommand.java
@@ -74,7 +74,7 @@ public class ExpelSubCommand implements SubCommandInterface {
             ConfigLoader.language.sendMessage(sender, "island.player.player-only-command");
             return true;
         }
-        if (!player.hasPermission("skyllia.island.command.expel")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.expel")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/GameRuleSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/GameRuleSubCommand.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionId;
 import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,7 +42,7 @@ public class GameRuleSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.gamerule")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.gamerule")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/HomeSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/HomeSubCommand.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import fr.euphyllia.skyllia.utils.WorldUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -34,7 +35,7 @@ public class HomeSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.home")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.home")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InfoSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InfoSubCommand.java
@@ -8,6 +8,7 @@ import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -35,7 +36,7 @@ public class InfoSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission(permission())) {
+        if (!PlayerUtils.hasPermission(player, permission())) {
             ConfigLoader.language.sendMessage(player, "island.info.no-permission");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InviteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InviteSubCommand.java
@@ -11,6 +11,7 @@ import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
 import fr.euphyllia.skyllia.cache.commands.InviteCacheExecution;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,7 +51,7 @@ public class InviteSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.invite")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.invite")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/KickSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/KickSubCommand.java
@@ -11,6 +11,7 @@ import fr.euphyllia.skyllia.api.skyblock.enums.RemovalCause;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.managers.skyblock.SkyblockManager;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.NamespacedKey;
@@ -42,7 +43,7 @@ public class KickSubCommand implements SubCommandInterface {
             ConfigLoader.language.sendMessage(sender, "island.player.player-only-command");
             return true;
         }
-        if (!sender.hasPermission("skyllia.island.command.kick")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.kick")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
@@ -91,7 +92,7 @@ public class KickSubCommand implements SubCommandInterface {
     @Override
     public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NotNull String[] args) {
         if (!(sender instanceof Player player)) return Collections.emptyList();
-        if (!sender.hasPermission("skyllia.island.command.kick")) return Collections.emptyList();
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.kick")) return Collections.emptyList();
 
         if (args.length == 1) {
             String partial = args[0].trim().toLowerCase();

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/LeaveSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/LeaveSubCommand.java
@@ -9,6 +9,7 @@ import fr.euphyllia.skyllia.api.skyblock.enums.RemovalCause;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.managers.skyblock.SkyblockManager;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.command.CommandSender;
@@ -30,7 +31,7 @@ public class LeaveSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.leave")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.leave")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/PermissionSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/PermissionSubCommand.java
@@ -8,6 +8,7 @@ import fr.euphyllia.skyllia.api.permissions.*;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.NamespacedKey;
@@ -71,7 +72,7 @@ public class PermissionSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.permission")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.permission")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
@@ -249,7 +250,7 @@ public class PermissionSubCommand implements SubCommandInterface {
     @Override
     public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NotNull String[] args) {
         if (!(sender instanceof Player player)) return Collections.emptyList();
-        if (!player.hasPermission("skyllia.island.command.permission")) return Collections.emptyList();
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.permission")) return Collections.emptyList();
 
         PermissionRegistry registry = SkylliaAPI.getPermissionRegistry();
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/PromoteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/PromoteSubCommand.java
@@ -9,6 +9,7 @@ import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,7 +44,7 @@ public class PromoteSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.promote")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.promote")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
@@ -110,7 +111,7 @@ public class PromoteSubCommand implements SubCommandInterface {
     @Override
     public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NotNull String[] args) {
         if (!(sender instanceof Player player)) return Collections.emptyList();
-        if (!player.hasPermission("skyllia.island.command.promote")) return Collections.emptyList();
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.promote")) return Collections.emptyList();
 
         if (args.length == 1) {
             String partial = args[0].trim().toLowerCase();

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/SetBiomeSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/SetBiomeSubCommand.java
@@ -13,6 +13,7 @@ import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.api.utils.nms.BiomesImpl;
 import fr.euphyllia.skyllia.cache.commands.CommandCacheExecution;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import fr.euphyllia.skyllia.utils.WorldUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -51,7 +52,7 @@ public class SetBiomeSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.biome")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.biome")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
@@ -76,7 +77,7 @@ public class SetBiomeSubCommand implements SubCommandInterface {
         String biomeName = biomesImpl.getNameBiome(biome);
         String biomeRaw = biomeName.split(":")[1];
 
-        if (!player.hasPermission("skyllia.island.command.biome.%s".formatted(biomeRaw))) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.biome.%s".formatted(biomeRaw))) {
             ConfigLoader.language.sendMessage(player, "island.biome.permission-denied", Map.of("%s", selectBiome));
             return true;
         }
@@ -129,7 +130,7 @@ public class SetBiomeSubCommand implements SubCommandInterface {
             String messageToSend;
 
             if (args.length >= 2 && args[1].equalsIgnoreCase("island")
-                    && player.hasPermission("skyllia.island.command.biome_island")) {
+                    && PlayerUtils.hasPermission(player, "skyllia.island.command.biome_island")) {
 
                 changeBiomeFuture = Skyllia.getInstance().getInterneAPI().getWorldModifier(SchematicPlugin.UNKNOWN).changeBiomeIsland(world, biome, island, ConfigLoader.general.getRegionDistance());
                 messageToSend = "island.biome.island-success";

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/SetHomeSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/SetHomeSubCommand.java
@@ -10,6 +10,7 @@ import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.api.skyblock.model.Position;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,7 +46,7 @@ public class SetHomeSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.sethome")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.sethome")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/SetWarpSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/SetWarpSubCommand.java
@@ -10,6 +10,7 @@ import fr.euphyllia.skyllia.api.skyblock.model.Position;
 import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import fr.euphyllia.skyllia.utils.WorldUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -50,7 +51,7 @@ public class SetWarpSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.setwarp")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.setwarp")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/TPSSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/TPSSubCommand.java
@@ -4,6 +4,7 @@ import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
 import fr.euphyllia.skyllia.api.utils.TPSFormatter;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import fr.euphyllia.skyllia.utils.WorldUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -24,7 +25,7 @@ public class TPSSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.tps")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.tps")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/TransferSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/TransferSubCommand.java
@@ -9,6 +9,7 @@ import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.managers.skyblock.SkyblockManager;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
@@ -37,7 +38,7 @@ public class TransferSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.transfer")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.transfer")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/TrustSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/TrustSubCommand.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionId;
 import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,7 +47,7 @@ public class TrustSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.access")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.access")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/UnbanSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/UnbanSubCommand.java
@@ -8,6 +8,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.NamespacedKey;
@@ -40,7 +41,7 @@ public class UnbanSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.unban")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.unban")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/UntrustSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/UntrustSubCommand.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionId;
 import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -47,7 +48,7 @@ public class UntrustSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.access")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.access")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/VisitSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/VisitSubCommand.java
@@ -11,6 +11,7 @@ import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import fr.euphyllia.skyllia.utils.WorldUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -48,7 +49,7 @@ public class VisitSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.visit")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.visit")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/WarpSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/WarpSubCommand.java
@@ -8,6 +8,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -48,7 +49,7 @@ public class WarpSubCommand implements SubCommandInterface {
             return true;
         }
 
-        if (!player.hasPermission("skyllia.island.command.warp")) {
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.warp")) {
             ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
             return true;
         }
@@ -90,7 +91,7 @@ public class WarpSubCommand implements SubCommandInterface {
     @Override
     public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NotNull String[] args) {
         if (!(sender instanceof Player player)) return Collections.emptyList();
-        if (!player.hasPermission("skyllia.island.command.warp")) return Collections.emptyList();
+        if (!PlayerUtils.hasPermission(player, "skyllia.island.command.warp")) return Collections.emptyList();
         if (args.length != 1) return Collections.emptyList();
 
         Island island = SkylliaAPI.getIslandByPlayerId(player.getUniqueId());

--- a/plugin/src/main/java/fr/euphyllia/skyllia/configuration/ConfigLoader.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/configuration/ConfigLoader.java
@@ -84,6 +84,15 @@ public class ConfigLoader {
                 manager.loadConfig();
             }
             logger.log(Level.INFO, "[Config] Reload complete.");
+
+            if (general.isDebugPermission()) {
+                logger.log(Level.WARN, "!!! Warning !!!\n" +
+                        "Verbose permission debugging is active.\n" +
+                        "Although single hasPermission checks are very fast,\n" +
+                        "too many checks will cause massive permission log spamming in the console,\n" +
+                        "leading to high I/O load and potential server slowdown \n" +
+                        "during heavy Skyllia command usage.");
+            }
         } catch (DatabaseException exception) {
             logger.error(exception);
         }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/bukkitevents/paper/PortalAlternativePaperEvent.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/bukkitevents/paper/PortalAlternativePaperEvent.java
@@ -5,6 +5,7 @@ import fr.euphyllia.skyllia.api.configuration.WorldConfig;
 import fr.euphyllia.skyllia.api.event.players.PlayerPrepareChangeWorldSkyblockEvent;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.listeners.ListenersUtils;
+import fr.euphyllia.skyllia.utils.PlayerUtils;
 import io.papermc.paper.event.entity.EntityInsideBlockEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,14 +35,14 @@ public class PortalAlternativePaperEvent implements Listener {
             WorldConfig worldConfig = ConfigLoader.worldManager.getWorldConfig(world.getName());
             if (blockType.equals(Material.NETHER_PORTAL)) {
                 if (worldConfig.getPortalEnd().equalsIgnoreCase(world.getName())) return;
-                if (!player.hasPermission("skyllia.use.portal.nether")) return;
+                if (!PlayerUtils.hasPermission(player, "skyllia.use.portal.nether")) return;
                 ListenersUtils.callPlayerPrepareChangeWorldSkyblockEvent(
                         player, worldConfig, PlayerPrepareChangeWorldSkyblockEvent.PortalType.NETHER, event
                 );
             }
             if (blockType.equals(Material.END_PORTAL)) {
                 if (worldConfig.getPortalEnd().equalsIgnoreCase(world.getName())) return;
-                if (!player.hasPermission("skyllia.use.portal.end")) return;
+                if (!PlayerUtils.hasPermission(player, "skyllia.use.portal.end")) return;
                 ListenersUtils.callPlayerPrepareChangeWorldSkyblockEvent(
                         player, worldConfig, PlayerPrepareChangeWorldSkyblockEvent.PortalType.END, event
                 );

--- a/plugin/src/main/java/fr/euphyllia/skyllia/utils/PlayerUtils.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/utils/PlayerUtils.java
@@ -5,6 +5,8 @@ import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skyllia.api.event.players.PlayerTeleportSpawnEvent;
 import fr.euphyllia.skyllia.api.hooks.SpawnHook;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -41,5 +43,29 @@ public class PlayerUtils {
             player.teleportAsync(playerTeleportSpawnEvent.getFinalLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
         }, null, 1L);
 
+    }
+
+    // TODO: i18n support and optimise the code
+    public static boolean hasPermission(Player player, String key){
+        var result = player.hasPermission(key);
+
+        if(!ConfigLoader.general.isDebugPermission())
+            return result;
+
+        var text = Component.text()
+                .append(Component.text("player "))
+                .append(player.name());
+
+        if (result) {
+            text.append(Component.text(" HAVE ").color(NamedTextColor.GREEN));
+        } else {
+            text.append(Component.text(" DOESN'T HAVE ").color(NamedTextColor.RED));
+        }
+
+        text.append(Component.text(key)).append(Component.text("permission"));
+
+        Bukkit.getConsoleSender().sendMessage(text.build());
+
+        return result;
     }
 }


### PR DESCRIPTION
# Description 
This PR implements permission checks when `debug.permission` is enabled, and also moving permission validation part to PlayerUtils.java for unified responsibility of feature
<!-- TODO: write better description ?-->

# Screenshot 
<img width="1097" height="516" alt="console logging after enabled debug permission validation with non-op and op" src="https://github.com/user-attachments/assets/c67da157-8e1c-448f-8c40-a44aa50c29f2" />

# How to use
1. Change config.toml, set `permission` under section `[debug]` property to `true`  
It should be looks like:
```toml
[debug]
permission = true
```
2. Reload plugin

# Drawbacks
After verbose is enabled, the bunch logging stream might make console slower to answer due to external reason (operating system / console stream handling, but it usually because I/O delays the console and it might make server slower to work). Please use in debugging or maintenance work, but in production stage is not recommended.