### PR TITLE
Fix fallback when configured spawn world is missing

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/configuration/manager/GeneralConfigManager.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/configuration/manager/GeneralConfigManager.java
@@ -145,7 +145,16 @@ public class GeneralConfigManager implements IConfigurationProvider {
     }
 
     public Location getSpawnLocation() {
-        return spawnEnabled ? new Location(Bukkit.getWorld(spawnWorld), spawnX, spawnY, spawnZ, spawnYaw, spawnPitch) : null;
+        if (!spawnEnabled) {
+            return null;
+        }
+
+        var world = Bukkit.getWorld(spawnWorld);
+        if (world == null) {
+            return null;
+        }
+
+        return new Location(world, spawnX, spawnY, spawnZ, spawnYaw, spawnPitch);
     }
 
     public int getRegionDistance() {

--- a/plugin/src/main/java/fr/euphyllia/skyllia/utils/PlayerUtils.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/utils/PlayerUtils.java
@@ -34,7 +34,7 @@ public class PlayerUtils {
             }
 
             Location location = ConfigLoader.general.getSpawnLocation();
-            if (location == null) location = Bukkit.getWorlds().getFirst().getSpawnLocation();
+            if (location == null || location.getWorld() == null) location = Bukkit.getWorlds().getFirst().getSpawnLocation();
             PlayerTeleportSpawnEvent playerTeleportSpawnEvent = new PlayerTeleportSpawnEvent(player, location);
             Bukkit.getPluginManager().callEvent(playerTeleportSpawnEvent);
             if (playerTeleportSpawnEvent.isCancelled()) {


### PR DESCRIPTION
## Summary
- Return `null` from `getSpawnLocation()` when the configured world is unavailable.
- Fallback to the default world spawn when the configured spawn location has no world.

## Validation
- `git diff --check`
- `bash ./gradlew :plugin:compileJava :addons:SkylliaChat:compileJava --console=plain --no-daemon` *(currently blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
