### PR TITLE
Fix island deletion counter with non-deletable worlds

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -140,7 +141,11 @@ public class DeleteSubCommand implements SubCommandInterface {
                 this.updatePlayer(skyblockManager, island);
                 this.kickAllPlayerOnIsland(island);
 
-                AtomicInteger worldsLeft = new AtomicInteger(ConfigLoader.worldManager.getWorldConfigs().size());
+                List<String> worldsToDelete = ConfigLoader.worldManager.getWorldConfigs().entrySet().stream()
+                        .filter(entry -> entry.getValue().shouldDeleteIsland())
+                        .map(Map.Entry::getKey)
+                        .toList();
+                AtomicInteger worldsLeft = new AtomicInteger(worldsToDelete.size());
                 AtomicBoolean failed = new AtomicBoolean(false);
 
                 if (worldsLeft.get() == 0) {
@@ -152,16 +157,13 @@ public class DeleteSubCommand implements SubCommandInterface {
                     return;
                 }
 
-                ConfigLoader.worldManager.getWorldConfigs().forEach((s, envs) -> {
-                    if (envs.shouldDeleteIsland()) {
-                        Skyllia.getInstance().getInterneAPI().getWorldModifier(SchematicPlugin.UNKNOWN).deleteIsland(island, Bukkit.getWorld(s), ConfigLoader.general.getRegionDistance(), (success) -> {
-                            if (!success) failed.set(true);
-                            if (worldsLeft.decrementAndGet() == 0) {
-                                skyblockManager.setLockedIsland(island, failed.get());
-                            }
-                        });
-                    }
-
+                worldsToDelete.forEach(s -> {
+                    Skyllia.getInstance().getInterneAPI().getWorldModifier(SchematicPlugin.UNKNOWN).deleteIsland(island, Bukkit.getWorld(s), ConfigLoader.general.getRegionDistance(), (success) -> {
+                        if (!success) failed.set(true);
+                        if (worldsLeft.decrementAndGet() == 0) {
+                            skyblockManager.setLockedIsland(island, failed.get());
+                        }
+                    });
                 });
             } else {
                 ConfigLoader.language.sendMessage(player, "island.generic.unexpected-error");


### PR DESCRIPTION
## Summary
- Count only worlds that actually run island deletion callbacks.
- Prevent islands from staying locked forever when some configured worlds are not deletable.

## Validation
- `git diff --check`
- `bash ./gradlew :plugin:compileJava :addons:SkylliaChat:compileJava --console=plain --no-daemon` *(currently blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
