### PR TITLE
Fix async command dispatch and visit callback scheduling

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/SkylliaAdminCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/SkylliaAdminCommand.java
@@ -7,7 +7,6 @@ import fr.euphyllia.skyllia.api.commands.SubCommandRegistry;
 import fr.euphyllia.skyllia.commands.admin.subcommands.*;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NonNull;
@@ -43,8 +42,7 @@ public class SkylliaAdminCommand implements SkylliaCommandInterface {
                 ConfigLoader.language.sendMessage(player != null ? player : sender.getSender(), "misc.unknown-command");
                 return;
             }
-            Bukkit.getAsyncScheduler().runNow(this.plugin, task ->
-                    subCommandInterface.onExecute(this.plugin, sender.getSender(), listArgs));
+            subCommandInterface.onExecute(this.plugin, sender.getSender(), listArgs);
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/SkylliaCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/SkylliaCommand.java
@@ -7,7 +7,6 @@ import fr.euphyllia.skyllia.api.commands.SubCommandRegistry;
 import fr.euphyllia.skyllia.commands.common.subcommands.*;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
@@ -66,12 +65,10 @@ public class SkylliaCommand implements SkylliaCommandInterface {
                 ConfigLoader.language.sendMessage(sender.getSender(), "misc.unknown-command");
                 return;
             }
-            Bukkit.getAsyncScheduler().runNow(this.plugin, task ->
-                    subCommandInterface.onExecute(this.plugin, sender.getSender(), listArgs));
+            subCommandInterface.onExecute(this.plugin, sender.getSender(), listArgs);
         } else {
             // If no subcommand is provided, we can default to the "create" command
-            Bukkit.getAsyncScheduler().runNow(this.plugin, task ->
-                    registry.getSubCommandByName("create").onExecute(this.plugin, sender.getSender(), args));
+            registry.getSubCommandByName("create").onExecute(this.plugin, sender.getSender(), args);
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/VisitSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/VisitSubCommand.java
@@ -104,7 +104,7 @@ public class VisitSubCommand implements SubCommandInterface {
                     loc = warpIsland.location();
                 }
                 loc.setY(loc.getY() + 0.5);
-                player.teleportAsync(loc, PlayerTeleportEvent.TeleportCause.PLUGIN).thenRunAsync(() -> {
+                player.teleportAsync(loc, PlayerTeleportEvent.TeleportCause.PLUGIN).thenRun(() -> {
                     Skyllia.getInstance().getInterneAPI().getPlayerNMS().setOwnWorldBorder(Skyllia.getInstance(), player,
                             RegionHelper.getCenterRegion(loc.getWorld(), island.getPosition().x(), island.getPosition().z()), island.getSize(), 0, 0);
                     ConfigLoader.language.sendMessage(player, "island.visit.success", Map.of(


### PR DESCRIPTION
## Summary
- Execute player and admin subcommands on the calling thread instead of `AsyncScheduler`.
- Keep the post-teleport visit callback on the safe scheduler by replacing `thenRunAsync(...)`.

## Validation
- `git diff --check`
- `bash ./gradlew :plugin:compileJava :addons:SkylliaChat:compileJava --console=plain --no-daemon` *(currently blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
