### PR TITLE
Fix bypass checks when closing a private island

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/AccessSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/AccessSubCommand.java
@@ -77,18 +77,14 @@ public class AccessSubCommand implements SubCommandInterface {
                             entity -> {
                                 Player playerInIsland = (Player) entity;
 
-                                // NOTE: ton code d'origine check la permission sur "player" (le sender),
-                                // pas sur "playerInIsland". Je garde le même comportement.
-                                if (!PlayerUtils.hasPermission(player, "skyllia.island.command.access.bypass")) return;
+                                if (PlayerUtils.hasPermission(playerInIsland, "skyllia.island.command.access.bypass")) return;
 
-                                Bukkit.getAsyncScheduler().runNow(Skyllia.getInstance(), t -> {
-                                    Players players = island.getMember(playerInIsland.getUniqueId());
-                                    if (players == null
-                                            || players.getRoleType().equals(RoleType.BAN)
-                                            || players.getRoleType().equals(RoleType.VISITOR)) {
-                                        PlayerUtils.teleportPlayerSpawn(playerInIsland);
-                                    }
-                                });
+                                Players players = island.getMember(playerInIsland.getUniqueId());
+                                if (players == null
+                                        || players.getRoleType().equals(RoleType.BAN)
+                                        || players.getRoleType().equals(RoleType.VISITOR)) {
+                                    PlayerUtils.teleportPlayerSpawn(playerInIsland);
+                                }
                             }
                     );
                 });


### PR DESCRIPTION
## Summary
- Check the access bypass permission on the player found inside the island instead of the command sender.
- Teleport only visitors and banned players out of the island when access is closed.

## Validation
- `git diff --check`
- `bash ./gradlew :plugin:compileJava :addons:SkylliaChat:compileJava --console=plain --no-daemon` *(currently blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
