### PR TITLE
Fix island deletion counter with non-deletable worlds

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -149,19 +150,25 @@ public class DeleteSubCommand implements SubCommandInterface {
                 AtomicBoolean failed = new AtomicBoolean(false);
 
                 if (worldsLeft.get() == 0) {
-                    boolean lockResult = skyblockManager.setLockedIsland(island, false);
-                    if (!lockResult) {
-                        logger.log(Level.FATAL, "Failed to unlock island {} after deletion: unknown reason", island.getId());
-                    }
-                    ConfigLoader.language.sendMessage(player, "island.delete-success");
+                    finalizeDeletion(skyblockManager, island, false, player);
                     return;
                 }
 
-                worldsToDelete.forEach(s -> {
-                    Skyllia.getInstance().getInterneAPI().getWorldModifier(SchematicPlugin.UNKNOWN).deleteIsland(island, Bukkit.getWorld(s), ConfigLoader.general.getRegionDistance(), (success) -> {
+                worldsToDelete.forEach(worldName -> {
+                    World world = Bukkit.getWorld(worldName);
+                    if (world == null) {
+                        failed.set(true);
+                        logger.log(Level.FATAL, "Failed to delete island {} in world {}: world not loaded", island.getId(), worldName);
+                        if (worldsLeft.decrementAndGet() == 0) {
+                            finalizeDeletion(skyblockManager, island, failed.get(), player);
+                        }
+                        return;
+                    }
+
+                    Skyllia.getInstance().getInterneAPI().getWorldModifier(SchematicPlugin.UNKNOWN).deleteIsland(island, world, ConfigLoader.general.getRegionDistance(), (success) -> {
                         if (!success) failed.set(true);
                         if (worldsLeft.decrementAndGet() == 0) {
-                            skyblockManager.setLockedIsland(island, failed.get());
+                            finalizeDeletion(skyblockManager, island, failed.get(), player);
                         }
                     });
                 });
@@ -190,6 +197,27 @@ public class DeleteSubCommand implements SubCommandInterface {
             players.setRoleType(RoleType.VISITOR);
             island.updateMember(players);
             checkClearPlayer(skyblockManager, players, RemovalCause.ISLAND_DELETED);
+        }
+    }
+
+    private void finalizeDeletion(SkyblockManager skyblockManager, Island island, boolean failed, Player player) {
+        boolean lockResult = skyblockManager.setLockedIsland(island, failed);
+        if (!lockResult) {
+            logger.log(Level.FATAL, "Failed to update lock state for island {} after deletion", island.getId());
+            if (player.isOnline()) {
+                ConfigLoader.language.sendMessage(player, "island.generic.unexpected-error");
+            }
+            return;
+        }
+
+        if (!player.isOnline()) {
+            return;
+        }
+
+        if (failed) {
+            ConfigLoader.language.sendMessage(player, "island.generic.unexpected-error");
+        } else {
+            ConfigLoader.language.sendMessage(player, "island.delete-success");
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/DeleteSubCommand.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -140,7 +141,11 @@ public class DeleteSubCommand implements SubCommandInterface {
                 this.updatePlayer(skyblockManager, island);
                 this.kickAllPlayerOnIsland(island);
 
-                AtomicInteger worldsLeft = new AtomicInteger(ConfigLoader.worldManager.getWorldConfigs().size());
+                List<String> worldsToDelete = ConfigLoader.worldManager.getWorldConfigs().entrySet().stream()
+                        .filter(entry -> entry.getValue().shouldDeleteIsland())
+                        .map(Map.Entry::getKey)
+                        .toList();
+                AtomicInteger worldsLeft = new AtomicInteger(worldsToDelete.size());
                 AtomicBoolean failed = new AtomicBoolean(false);
 
                 if (worldsLeft.get() == 0) {
@@ -152,16 +157,13 @@ public class DeleteSubCommand implements SubCommandInterface {
                     return;
                 }
 
-                ConfigLoader.worldManager.getWorldConfigs().forEach((s, envs) -> {
-                    if (envs.shouldDeleteIsland()) {
-                        Skyllia.getInstance().getInterneAPI().getWorldModifier(SchematicPlugin.UNKNOWN).deleteIsland(island, Bukkit.getWorld(s), ConfigLoader.general.getRegionDistance(), (success) -> {
-                            if (!success) failed.set(true);
-                            if (worldsLeft.decrementAndGet() == 0) {
-                                skyblockManager.setLockedIsland(island, failed.get());
-                            }
-                        });
-                    }
-
+                worldsToDelete.forEach(s -> {
+                    Skyllia.getInstance().getInterneAPI().getWorldModifier(SchematicPlugin.UNKNOWN).deleteIsland(island, Bukkit.getWorld(s), ConfigLoader.general.getRegionDistance(), (success) -> {
+                        if (!success) failed.set(true);
+                        if (worldsLeft.decrementAndGet() == 0) {
+                            skyblockManager.setLockedIsland(island, failed.get());
+                        }
+                    });
                 });
             } else {
                 ConfigLoader.language.sendMessage(player, "island.generic.unexpected-error");


### PR DESCRIPTION
## Summary
- Count only worlds whose configuration actually enables island deletion.
- Treat missing configured worlds as failed deletions while still decrementing the remaining callback counter.
- Finalize the island lock state once after all deletion callbacks complete, with logging and player feedback for success or failure.

## Validation
- `git diff --check`
- `bash ./gradlew :plugin:compileJava --console=plain --no-daemon` *(still blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
