### PR TITLE
Fix invite cache invalidation order on accept

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InviteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InviteSubCommand.java
@@ -203,6 +203,8 @@ public class InviteSubCommand implements SubCommandInterface {
             int currentMembers = islandOwner.getMembers().size();
 
             if (currentMembers < maxMembers) {
+                InviteCacheExecution.removeInviteCache(islandOwner.getId(), playerWantJoin.getUniqueId());
+
                 Players newPlayer = new Players(
                         playerWantJoin.getUniqueId(),
                         playerWantJoin.getName(),
@@ -215,8 +217,6 @@ public class InviteSubCommand implements SubCommandInterface {
                     ConfigLoader.language.sendMessage(playerWantJoin, "island.generic.unexpected-error");
                     return;
                 }
-
-                InviteCacheExecution.removeInviteCache(islandOwner.getId(), playerWantJoin.getUniqueId());
 
                 ConfigLoader.language.sendMessage(playerWantJoin, "island.invite.join-success");
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InviteSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/InviteSubCommand.java
@@ -199,8 +199,6 @@ public class InviteSubCommand implements SubCommandInterface {
                 return;
             }
 
-            InviteCacheExecution.removeInviteCache(islandOwner.getId(), playerWantJoin.getUniqueId());
-
             int maxMembers = islandOwner.getMaxMembers();
             int currentMembers = islandOwner.getMembers().size();
 
@@ -217,6 +215,8 @@ public class InviteSubCommand implements SubCommandInterface {
                     ConfigLoader.language.sendMessage(playerWantJoin, "island.generic.unexpected-error");
                     return;
                 }
+
+                InviteCacheExecution.removeInviteCache(islandOwner.getId(), playerWantJoin.getUniqueId());
 
                 ConfigLoader.language.sendMessage(playerWantJoin, "island.invite.join-success");
 


### PR DESCRIPTION
## Summary
- Keep the invitation cached until capacity checks pass.
- Remove the invite only after `updateMember(...)` succeeds.

## Validation
- `git diff --check`
- `bash ./gradlew :plugin:compileJava :addons:SkylliaChat:compileJava --console=plain --no-daemon` *(currently blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
