### PR TITLE
Fix visit post-teleport callback scheduling

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/VisitSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/VisitSubCommand.java
@@ -104,7 +104,7 @@ public class VisitSubCommand implements SubCommandInterface {
                     loc = warpIsland.location();
                 }
                 loc.setY(loc.getY() + 0.5);
-                player.teleportAsync(loc, PlayerTeleportEvent.TeleportCause.PLUGIN).thenRunAsync(() -> {
+                player.teleportAsync(loc, PlayerTeleportEvent.TeleportCause.PLUGIN).thenRun(() -> {
                     Skyllia.getInstance().getInterneAPI().getPlayerNMS().setOwnWorldBorder(Skyllia.getInstance(), player,
                             RegionHelper.getCenterRegion(loc.getWorld(), island.getPosition().x(), island.getPosition().z()), island.getSize(), 0, 0);
                     ConfigLoader.language.sendMessage(player, "island.visit.success", Map.of(


### PR DESCRIPTION
## Summary
- Schedule the post-teleport visit follow-up with `thenRun(...)` instead of `thenRunAsync(...)`.
- Keep the world border update and success message aligned with the other `teleportAsync` callbacks already used in the plugin.

## Validation
- `git diff --check`
- `bash ./gradlew :plugin:compileJava --console=plain --no-daemon` *(still blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
