### PR TITLE
Escape MiniMessage placeholders in island chat

### DIFF
--- a/addons/SkylliaChat/src/main/java/fr/euphyllia/skylliachat/ChatListeners.java
+++ b/addons/SkylliaChat/src/main/java/fr/euphyllia/skylliachat/ChatListeners.java
@@ -4,7 +4,9 @@ import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -50,8 +52,8 @@ public class ChatListeners implements Listener {
 
                 String message = event.getMessage();
                 String format = this.plugin.getConfig().getString("chat.format", "<red>[Messaging Island] %player_name%: <gray>%message%")
-                        .replace("%player_name%", playerName)
-                        .replace("%message%", message);
+                        .replace("%player_name%", "<player_name>")
+                        .replace("%message%", "<message>");
 
                 // MiniMessage doesn't like legacy formatting codes...
                 format = ChatColor.translateAlternateColorCodes('&', format)
@@ -78,11 +80,14 @@ public class ChatListeners implements Listener {
                         .replace("§n", "<underlined>")
                         .replace("§o", "<italic>");
 
+                Component islandMessage = miniMessage.deserialize(format,
+                        Placeholder.unparsed("player_name", playerName),
+                        Placeholder.unparsed("message", message));
 
                 for (Players islandMember : island.getMembers()) {
                     OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(islandMember.getMojangId());
                     if (offlinePlayer.isOnline() && offlinePlayer.getPlayer() != null) {
-                        offlinePlayer.getPlayer().sendMessage(miniMessage.deserialize(format));
+                        offlinePlayer.getPlayer().sendMessage(islandMessage);
                     }
                 }
             });

--- a/addons/SkylliaChat/src/main/java/fr/euphyllia/skylliachat/ChatListeners.java
+++ b/addons/SkylliaChat/src/main/java/fr/euphyllia/skylliachat/ChatListeners.java
@@ -15,7 +15,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
-import java.util.List;
 import java.util.UUID;
 
 public class ChatListeners implements Listener {
@@ -43,55 +42,50 @@ public class ChatListeners implements Listener {
         if (plugin.getIslandChatEnabled().getOrDefault(uuid, false)) {
             event.setCancelled(true);
 
-            Island island = SkylliaAPI.getIslandByPlayerId(uuid);
-            if (island == null) {
-                player.getScheduler().execute(plugin, () ->
-                        ConfigLoader.language.sendMessage(player, "island.player.no-island"), null, 0L);
-                return;
-            }
-            List<UUID> memberIds = island.getMembers().stream()
-                    .map(Players::getMojangId)
-                    .toList();
+            Bukkit.getAsyncScheduler().runNow(plugin, scheduledTask -> {
+                Island island = SkylliaAPI.getIslandByPlayerId(uuid);
+                if (island == null) {
+                    ConfigLoader.language.sendMessage(player, "island.player.no-island");
+                    return;
+                }
 
-            String message = event.getMessage();
-            String format = this.plugin.getConfig().getString("chat.format", "<red>[Messaging Island] %player_name%: <gray>%message%")
-                    .replace("%player_name%", "<player_name>")
-                    .replace("%message%", "<message>");
+                String message = event.getMessage();
+                String format = this.plugin.getConfig().getString("chat.format", "<red>[Messaging Island] %player_name%: <gray>%message%")
+                        .replace("%player_name%", "<player_name>")
+                        .replace("%message%", "<message>");
 
-            // MiniMessage doesn't like legacy formatting codes...
-            format = ChatColor.translateAlternateColorCodes('&', format)
-                    .replace("§0", "<black>")
-                    .replace("§1", "<dark_blue>")
-                    .replace("§2", "<dark_green>")
-                    .replace("§3", "<dark_aqua>")
-                    .replace("§4", "<dark_red>")
-                    .replace("§5", "<dark_purple>")
-                    .replace("§6", "<gold>")
-                    .replace("§7", "<gray>")
-                    .replace("§8", "<dark_gray>")
-                    .replace("§9", "<blue>")
-                    .replace("§a", "<green>")
-                    .replace("§b", "<aqua>")
-                    .replace("§c", "<red>")
-                    .replace("§d", "<light_purple>")
-                    .replace("§e", "<yellow>")
-                    .replace("§f", "<white>")
-                    .replace("§r", "<reset>")
-                    .replace("§k", "<obfuscated>")
-                    .replace("§l", "<bold>")
-                    .replace("§m", "<strikethrough>")
-                    .replace("§n", "<underlined>")
-                    .replace("§o", "<italic>");
+                format = ChatColor.translateAlternateColorCodes('&', format)
+                        .replace("§0", "<black>")
+                        .replace("§1", "<dark_blue>")
+                        .replace("§2", "<dark_green>")
+                        .replace("§3", "<dark_aqua>")
+                        .replace("§4", "<dark_red>")
+                        .replace("§5", "<dark_purple>")
+                        .replace("§6", "<gold>")
+                        .replace("§7", "<gray>")
+                        .replace("§8", "<dark_gray>")
+                        .replace("§9", "<blue>")
+                        .replace("§a", "<green>")
+                        .replace("§b", "<aqua>")
+                        .replace("§c", "<red>")
+                        .replace("§d", "<light_purple>")
+                        .replace("§e", "<yellow>")
+                        .replace("§f", "<white>")
+                        .replace("§r", "<reset>")
+                        .replace("§k", "<obfuscated>")
+                        .replace("§l", "<bold>")
+                        .replace("§m", "<strikethrough>")
+                        .replace("§n", "<underlined>")
+                        .replace("§o", "<italic>");
 
-            Component islandMessage = miniMessage.deserialize(format,
-                    Placeholder.unparsed("player_name", playerName),
-                    Placeholder.unparsed("message", message));
+                Component islandMessage = miniMessage.deserialize(format,
+                        Placeholder.unparsed("player_name", playerName),
+                        Placeholder.unparsed("message", message));
 
-            Bukkit.getGlobalRegionScheduler().execute(plugin, () -> {
-                for (UUID memberId : memberIds) {
-                    Player member = Bukkit.getPlayer(memberId);
+                for (Players islandMember : island.getMembers()) {
+                    Player member = Bukkit.getPlayer(islandMember.getMojangId());
                     if (member != null && member.isOnline()) {
-                        member.getScheduler().execute(plugin, () -> member.sendMessage(islandMessage), null, 0L);
+                        member.sendMessage(islandMessage);
                     }
                 }
             });

--- a/addons/SkylliaChat/src/main/java/fr/euphyllia/skylliachat/ChatListeners.java
+++ b/addons/SkylliaChat/src/main/java/fr/euphyllia/skylliachat/ChatListeners.java
@@ -9,13 +9,13 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
+import java.util.List;
 import java.util.UUID;
 
 public class ChatListeners implements Listener {
@@ -43,51 +43,55 @@ public class ChatListeners implements Listener {
         if (plugin.getIslandChatEnabled().getOrDefault(uuid, false)) {
             event.setCancelled(true);
 
-            Bukkit.getAsyncScheduler().runNow(plugin, scheduledTask -> {
-                Island island = SkylliaAPI.getIslandByPlayerId(uuid);
-                if (island == null) {
-                    ConfigLoader.language.sendMessage(player, "island.player.no-island");
-                    return;
-                }
+            Island island = SkylliaAPI.getIslandByPlayerId(uuid);
+            if (island == null) {
+                player.getScheduler().execute(plugin, () ->
+                        ConfigLoader.language.sendMessage(player, "island.player.no-island"), null, 0L);
+                return;
+            }
+            List<UUID> memberIds = island.getMembers().stream()
+                    .map(Players::getMojangId)
+                    .toList();
 
-                String message = event.getMessage();
-                String format = this.plugin.getConfig().getString("chat.format", "<red>[Messaging Island] %player_name%: <gray>%message%")
-                        .replace("%player_name%", "<player_name>")
-                        .replace("%message%", "<message>");
+            String message = event.getMessage();
+            String format = this.plugin.getConfig().getString("chat.format", "<red>[Messaging Island] %player_name%: <gray>%message%")
+                    .replace("%player_name%", "<player_name>")
+                    .replace("%message%", "<message>");
 
-                // MiniMessage doesn't like legacy formatting codes...
-                format = ChatColor.translateAlternateColorCodes('&', format)
-                        .replace("§0", "<black>")
-                        .replace("§1", "<dark_blue>")
-                        .replace("§2", "<dark_green>")
-                        .replace("§3", "<dark_aqua>")
-                        .replace("§4", "<dark_red>")
-                        .replace("§5", "<dark_purple>")
-                        .replace("§6", "<gold>")
-                        .replace("§7", "<gray>")
-                        .replace("§8", "<dark_gray>")
-                        .replace("§9", "<blue>")
-                        .replace("§a", "<green>")
-                        .replace("§b", "<aqua>")
-                        .replace("§c", "<red>")
-                        .replace("§d", "<light_purple>")
-                        .replace("§e", "<yellow>")
-                        .replace("§f", "<white>")
-                        .replace("§r", "<reset>")
-                        .replace("§k", "<obfuscated>")
-                        .replace("§l", "<bold>")
-                        .replace("§m", "<strikethrough>")
-                        .replace("§n", "<underlined>")
-                        .replace("§o", "<italic>");
+            // MiniMessage doesn't like legacy formatting codes...
+            format = ChatColor.translateAlternateColorCodes('&', format)
+                    .replace("§0", "<black>")
+                    .replace("§1", "<dark_blue>")
+                    .replace("§2", "<dark_green>")
+                    .replace("§3", "<dark_aqua>")
+                    .replace("§4", "<dark_red>")
+                    .replace("§5", "<dark_purple>")
+                    .replace("§6", "<gold>")
+                    .replace("§7", "<gray>")
+                    .replace("§8", "<dark_gray>")
+                    .replace("§9", "<blue>")
+                    .replace("§a", "<green>")
+                    .replace("§b", "<aqua>")
+                    .replace("§c", "<red>")
+                    .replace("§d", "<light_purple>")
+                    .replace("§e", "<yellow>")
+                    .replace("§f", "<white>")
+                    .replace("§r", "<reset>")
+                    .replace("§k", "<obfuscated>")
+                    .replace("§l", "<bold>")
+                    .replace("§m", "<strikethrough>")
+                    .replace("§n", "<underlined>")
+                    .replace("§o", "<italic>");
 
-                Component islandMessage = miniMessage.deserialize(format,
-                        Placeholder.unparsed("player_name", playerName),
-                        Placeholder.unparsed("message", message));
+            Component islandMessage = miniMessage.deserialize(format,
+                    Placeholder.unparsed("player_name", playerName),
+                    Placeholder.unparsed("message", message));
 
-                for (Players islandMember : island.getMembers()) {
-                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(islandMember.getMojangId());
-                    if (offlinePlayer.isOnline() && offlinePlayer.getPlayer() != null) {
-                        offlinePlayer.getPlayer().sendMessage(islandMessage);
+            Bukkit.getGlobalRegionScheduler().execute(plugin, () -> {
+                for (UUID memberId : memberIds) {
+                    Player member = Bukkit.getPlayer(memberId);
+                    if (member != null && member.isOnline()) {
+                        member.getScheduler().execute(plugin, () -> member.sendMessage(islandMessage), null, 0L);
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- Stop parsing player names and chat messages as MiniMessage tags in island chat.
- Convert the configured chat format into a MiniMessage template first, then inject `%player_name%` and `%message%` through unparsed placeholders.
- Preserve the safe scheduling flow for island lookup, recipient lookup, and message delivery on Folia-compatible schedulers.

## Validation
- `git diff --check`
- `bash ./gradlew :addons:SkylliaChat:compileJava --console=plain --no-daemon` *(still blocked by pre-existing `paperweightUserdevSetup` remap failures in `:nms:v1_21_R3`, `:nms:v1_21_R4`, and `:nms:v1_21_R5`)*
