### PR TITLE
fix: cascade .all flag toggle to all child flags

### DIFF
--- a/api/src/main/java/fr/euphyllia/skyllia/api/permissions/PermissionsManagers.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/permissions/PermissionsManagers.java
@@ -37,7 +37,7 @@ public class PermissionsManagers {
     public boolean hasFlag(Island island, FlagId specific, FlagId fallback) {
         var flags = island.getIslandFlags();
         var registry = SkylliaAPI.getFlagRegistry();
-        return flags.has(registry, specific) || flags.has(registry, fallback);
+        return flags.has(registry, specific);
     }
 
     /**

--- a/api/src/main/java/fr/euphyllia/skyllia/api/permissions/PermissionsManagers.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/permissions/PermissionsManagers.java
@@ -37,7 +37,7 @@ public class PermissionsManagers {
     public boolean hasFlag(Island island, FlagId specific, FlagId fallback) {
         var flags = island.getIslandFlags();
         var registry = SkylliaAPI.getFlagRegistry();
-        return flags.has(registry, specific);
+        return flags.has(registry, specific) || flags.has(registry, fallback);
     }
 
     /**

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/FlagSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/FlagSubCommand.java
@@ -212,13 +212,46 @@ public class FlagSubCommand implements SubCommandInterface {
         if (query == null) return false;
 
         IslandFlagRegistry registry = SkylliaAPI.getFlagRegistry();
-        boolean success = query.setFlag(island.getId(), registry, fid, value);
+
+        // When a ".all" flag is toggled, cascade the value to all children with the same prefix
+        FlagNode node = registry.node(fid);
+        NamespacedKey key = node.node();
+        String keyStr = key.getKey();
+
+        List<FlagId> childFlags = new ArrayList<>();
+
+        if (keyStr.endsWith(".all")) {
+            String prefix = keyStr.substring(0, keyStr.length() - 3);
+            for (Map.Entry<NamespacedKey, FlagId> entry : registry.entries().entrySet()) {
+                NamespacedKey k = entry.getKey();
+                if (k.getNamespace().equals(key.getNamespace())
+                        && k.getKey().startsWith(prefix)
+                        && !k.getKey().equals(keyStr)) {
+                    childFlags.add(entry.getValue());
+                }
+            }
+        }
+
+        // Load flags from DB, apply all changes at once, save once
+        IslandFlags dbFlags = query.loadIslandFlags(island.getId(), registry);
+        if (dbFlags == null) dbFlags = new IslandFlags(registry);
+
+        dbFlags.set(registry, fid, value);
+        for (FlagId child : childFlags) {
+            dbFlags.set(registry, child, value);
+        }
+
+        byte[] blob = PermissionSetCodec.encodeLongs(dbFlags.snapshotWords());
+        boolean success = query.saveIslandFlags(island.getId(), blob);
         if (!success) return false;
 
-
+        // Update runtime cache
         IslandFlags flags = island.getIslandFlags();
         flags.ensureUpToDate(registry);
         flags.set(registry, fid, value);
+        for (FlagId child : childFlags) {
+            flags.set(registry, child, value);
+        }
         return true;
     }
 


### PR DESCRIPTION
## Problem

When toggling a `.all` flag (e.g. `skyllia:island.spawn.hostile.all`), only the parent flag was updated. Child flags (e.g. `island.spawn.hostile.zombie`) were left unchanged.

This caused two issues:
1. **GUI confusion**: In menus like DeluxeMenus that read individual flag values, sub-flags still showed `false` even though `.all` was `true`
2. **Inconsistent behavior**: The OR fallback in `hasFlag(specific, fallback)` masked the issue at runtime, but the stored values were wrong

## Solution

**`FlagSubCommand.setDbAndRuntime()`**: When a flag key ends with `.all`, find all registered flags sharing the same prefix and set them to the same value. All changes are applied in a single DB write for performance.

**`PermissionsManagers.hasFlag(specific, fallback)`**: Now returns only the specific flag value. Since `.all` cascade is done at write time, the OR fallback is no longer needed and was actually preventing users from individually disabling specific sub-flags after enabling `.all`.

## Example

```
/is flag set skyllia:island.spawn.hostile.all true
→ All hostile mob flags (zombie, creeper, skeleton, ...) are now true

/is flag set skyllia:island.spawn.hostile.zombie false
→ Only zombie is disabled, all others remain true

/is flag set skyllia:island.spawn.hostile.all false
→ All hostile mob flags are now false
```

Works for all `.all` categories: `spawn.hostile.all`, `spawn.passive.all`, `spawn.boss.all`, `spawn.neutral.all`, etc.