### PR TITLE
New addon : Skyllia Acid Rain

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -11,6 +11,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/addons" />
             <option value="$PROJECT_DIR$/addons/InsightsSkyllia" />
+            <option value="$PROJECT_DIR$/addons/SkylliaAcidRain" />
             <option value="$PROJECT_DIR$/addons/SkylliaBank" />
             <option value="$PROJECT_DIR$/addons/SkylliaChallenge" />
             <option value="$PROJECT_DIR$/addons/SkylliaChat" />

--- a/addons/SkylliaAcidRain/build.gradle.kts
+++ b/addons/SkylliaAcidRain/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 group = "fr.euphyllia.skylliaacidrain"
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     compileOnly(project(":api"))
     compileOnly(project(":plugin"))
 }

--- a/addons/SkylliaAcidRain/build.gradle.kts
+++ b/addons/SkylliaAcidRain/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("java")
+}
+
+group = "fr.euphyllia.skylliaacidrain"
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
+    compileOnly(project(":api"))
+    compileOnly(project(":plugin"))
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+tasks {
+    compileJava {
+        options.encoding = "UTF-8"
+    }
+}

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/SkylliaAcidRain.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/SkylliaAcidRain.java
@@ -1,0 +1,18 @@
+package fr.euphyllia.skylliaacidrain;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class SkylliaAcidRain extends JavaPlugin {
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+    }
+
+    @Override
+    public void onDisable() {
+        Bukkit.getAsyncScheduler().cancelTasks(this);
+        Bukkit.getGlobalRegionScheduler().cancelTasks(this);
+    }
+}

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/SkylliaAcidRain.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/SkylliaAcidRain.java
@@ -1,17 +1,36 @@
 package fr.euphyllia.skylliaacidrain;
 
+import fr.euphyllia.skylliaacidrain.configuration.AcidConfigLoader;
+import fr.euphyllia.skylliaacidrain.listener.AcidListener;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class SkylliaAcidRain extends JavaPlugin {
 
+
+    private static final Logger log = LoggerFactory.getLogger(SkylliaAcidRain.class);
+
     @Override
     public void onEnable() {
-        saveDefaultConfig();
+
+        AcidListener acidListener = new AcidListener(this);
+
+        try {
+            AcidConfigLoader.init(getDataFolder(), acidListener);
+        } catch (Exception e) {
+            log.error("Error while loading AcidConfig", e);
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        getServer().getPluginManager().registerEvents(acidListener, this);
     }
 
     @Override
     public void onDisable() {
+        AcidConfigLoader.unregister();
         Bukkit.getAsyncScheduler().cancelTasks(this);
         Bukkit.getGlobalRegionScheduler().cancelTasks(this);
     }

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigLoader.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigLoader.java
@@ -1,0 +1,33 @@
+package fr.euphyllia.skylliaacidrain.configuration;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skylliaacidrain.listener.AcidListener;
+
+import java.io.File;
+
+public class AcidConfigLoader {
+
+    public static AcidConfigManager config;
+
+    public static void init(File dataFolder, AcidListener listener) throws Exception {
+        File configDir = new File(dataFolder, "config");
+        //noinspection ResultOfMethodCallIgnored
+        configDir.mkdirs();
+        config = new AcidConfigManager(loadFile(new File(configDir, "config.toml")), listener);
+
+        config.loadConfig();
+
+        SkylliaAPI.getConfigRegistry().registerConfig(config);
+    }
+
+    public static void unregister() {
+        if (config != null) SkylliaAPI.getConfigRegistry().unregisterConfig(config);
+    }
+
+    private static CommentedFileConfig loadFile(File file) {
+        CommentedFileConfig cfg = CommentedFileConfig.builder(file).sync().autosave().build();
+        cfg.load();
+        return cfg;
+    }
+}

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigManager.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigManager.java
@@ -14,7 +14,7 @@ public class AcidConfigManager implements IConfigurationProvider {
     private boolean changed = false;
 
     private double damage;
-    private long damageIntervalMs;
+    private long damageIntervalTick;
     private boolean particles;
     private boolean sound;
     private String soundName;
@@ -41,7 +41,7 @@ public class AcidConfigManager implements IConfigurationProvider {
         changed = false;
 
         this.damage = getOrSetDefault("acid.damage", 2.0, Double.class);
-        this.damageIntervalMs = getOrSetDefault("acid.damage-interval-ms", 1000L, Long.class);
+        this.damageIntervalTick = getOrSetDefault("acid.damage-interval-tick", 20L, Long.class); // 20 tick = 1 second
 
         this.particles = getOrSetDefault("acid.particles", true, Boolean.class);
         this.sound = getOrSetDefault("acid.sound.enabled", true, Boolean.class);
@@ -105,8 +105,8 @@ public class AcidConfigManager implements IConfigurationProvider {
         return damage;
     }
 
-    public long getDamageIntervalMs() {
-        return damageIntervalMs;
+    public long getDamageIntervalTick() {
+        return damageIntervalTick;
     }
 
     public boolean isParticles() {

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigManager.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigManager.java
@@ -6,9 +6,12 @@ import com.electronwill.nightconfig.core.io.WritingMode;
 import com.electronwill.nightconfig.toml.TomlWriter;
 import fr.euphyllia.skyllia.api.configuration.IConfigurationProvider;
 import fr.euphyllia.skylliaacidrain.listener.AcidListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AcidConfigManager implements IConfigurationProvider {
 
+    private static final Logger log = LoggerFactory.getLogger(AcidConfigManager.class);
     private final AcidListener acidListener;
     private final CommentedFileConfig config;
     private boolean changed = false;
@@ -69,7 +72,7 @@ public class AcidConfigManager implements IConfigurationProvider {
             tomlWriter.write(config, config.getFile(), WritingMode.REPLACE);
         }
 
-
+        log.info("(Re)Loaded config SkylliaAcidRain");
     }
 
     @Override

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigManager.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/configuration/AcidConfigManager.java
@@ -1,0 +1,164 @@
+package fr.euphyllia.skylliaacidrain.configuration;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.electronwill.nightconfig.core.io.IndentStyle;
+import com.electronwill.nightconfig.core.io.WritingMode;
+import com.electronwill.nightconfig.toml.TomlWriter;
+import fr.euphyllia.skyllia.api.configuration.IConfigurationProvider;
+import fr.euphyllia.skylliaacidrain.listener.AcidListener;
+
+public class AcidConfigManager implements IConfigurationProvider {
+
+    private final AcidListener acidListener;
+    private final CommentedFileConfig config;
+    private boolean changed = false;
+
+    private double damage;
+    private long damageIntervalMs;
+    private boolean particles;
+    private boolean sound;
+    private String soundName;
+
+    private boolean onlyPlayer;
+
+    private boolean poisonEnabled;
+    private int poisonDuration;
+    private int poisonAmplifier;
+    private boolean slownessEnabled;
+    private int slownessDuration;
+    private int slownessAmplifier;
+    private boolean nauseaEnabled;
+    private int nauseaDuration;
+    private int nauseaAmplifier;
+
+    public AcidConfigManager(CommentedFileConfig config, AcidListener listener) {
+        this.config = config;
+        this.acidListener = listener;
+    }
+
+    @Override
+    public void loadConfig() {
+        changed = false;
+
+        this.damage = getOrSetDefault("acid.damage", 2.0, Double.class);
+        this.damageIntervalMs = getOrSetDefault("acid.damage-interval-ms", 1000L, Long.class);
+
+        this.particles = getOrSetDefault("acid.particles", true, Boolean.class);
+        this.sound = getOrSetDefault("acid.sound.enabled", true, Boolean.class);
+        this.soundName = getOrSetDefault("acid.sound.name", "BLOCK_LAVA_AMBIENT", String.class);
+
+        this.onlyPlayer = getOrSetDefault("acid.only-player", false, Boolean.class);
+
+        this.poisonEnabled = getOrSetDefault("acid.effects.poison.enabled", true, Boolean.class);
+        this.poisonDuration = getOrSetDefault("acid.effects.poison.duration", 60, Integer.class);
+        this.poisonAmplifier = getOrSetDefault("acid.effects.poison.amplifier", 1, Integer.class);
+
+        this.slownessEnabled = getOrSetDefault("acid.effects.slowness.enabled", true, Boolean.class);
+        this.slownessDuration = getOrSetDefault("acid.effects.slowness.duration", 40, Integer.class);
+        this.slownessAmplifier = getOrSetDefault("acid.effects.slowness.amplifier", 0, Integer.class);
+
+        this.nauseaEnabled = getOrSetDefault("acid.effects.nausea.enabled", true, Boolean.class);
+        this.nauseaDuration = getOrSetDefault("acid.effects.nausea.duration", 80, Integer.class);
+        this.nauseaAmplifier = getOrSetDefault("acid.effects.nausea.amplifier", 0, Integer.class);
+
+        this.acidListener.restartAllTasks();
+
+        if (changed) {
+            TomlWriter tomlWriter = new TomlWriter();
+            tomlWriter.setIndent(IndentStyle.NONE);
+            tomlWriter.write(config, config.getFile(), WritingMode.REPLACE);
+        }
+
+
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getOrSetDefault(String path, T defaultValue, Class<T> expectedClass) {
+        Object value = config.get(path);
+        if (value == null) {
+            config.set(path, defaultValue);
+            changed = true;
+            return defaultValue;
+        }
+        if (expectedClass.isInstance(value)) return (T) value;
+        return switch (value) {
+            case Integer i when expectedClass == Long.class -> (T) Long.valueOf(i);
+            case Double d when expectedClass == Float.class -> (T) Float.valueOf(d.floatValue());
+            case Integer i when expectedClass == Double.class -> (T) Double.valueOf(i);
+            default -> throw new IllegalStateException("Cannot convert value at '" + path + "' from "
+                    + value.getClass().getSimpleName() + " to " + expectedClass.getSimpleName());
+        };
+    }
+
+    @Override
+    public void reloadFromDisk() {
+        config.load();
+    }
+
+    @Override
+    public boolean canReloadFromDisk() {
+        return true;
+    }
+
+    public double getDamage() {
+        return damage;
+    }
+
+    public long getDamageIntervalMs() {
+        return damageIntervalMs;
+    }
+
+    public boolean isParticles() {
+        return particles;
+    }
+
+    public boolean isSound() {
+        return sound;
+    }
+
+    public String getSoundName() {
+        return soundName;
+    }
+
+    public boolean isOnlyPlayer() {
+        return onlyPlayer;
+    }
+
+    public boolean isPoisonEnabled() {
+        return poisonEnabled;
+    }
+
+    public int getPoisonDuration() {
+        return poisonDuration;
+    }
+
+    public int getPoisonAmplifier() {
+        return poisonAmplifier;
+    }
+
+    public boolean isSlownessEnabled() {
+        return slownessEnabled;
+    }
+
+    public int getSlownessDuration() {
+        return slownessDuration;
+    }
+
+    public int getSlownessAmplifier() {
+        return slownessAmplifier;
+    }
+
+    public boolean isNauseaEnabled() {
+        return nauseaEnabled;
+    }
+
+    public int getNauseaDuration() {
+        return nauseaDuration;
+    }
+
+    public int getNauseaAmplifier() {
+        return nauseaAmplifier;
+    }
+
+}

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
@@ -188,8 +188,8 @@ public class AcidListener implements Listener {
 
         if (entity instanceof Player player) {
             Component msg = inWater
-                    ? ConfigLoader.language.translate(player, "addons.acid-island.water-contact")
-                    : ConfigLoader.language.translate(player, "addons.acid-island.rain-contact");
+                    ? ConfigLoader.language.translate(player.locale(), "addons.acid-island.water-contact", Map.of(), false)
+                    : ConfigLoader.language.translate(player.locale(), "addons.acid-island.rain-contact", Map.of(), false);
             player.sendActionBar(msg);
         }
     }

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
@@ -97,14 +97,14 @@ public class AcidListener implements Listener {
 
     private void startTask(LivingEntity entity) {
         UUID uuid = entity.getUniqueId();
-        long intervalMs = AcidConfigLoader.config.getDamageIntervalMs();
+        long intervalTick = AcidConfigLoader.config.getDamageIntervalMs();
 
         ScheduledTask task = entity.getScheduler().runAtFixedRate(
                 plugin,
                 scheduledTask -> handleAcidTick(entity),
                 null,
-                intervalMs,
-                intervalMs
+                intervalTick,
+                intervalTick
         );
 
         if (task != null) {

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
@@ -1,15 +1,196 @@
 package fr.euphyllia.skylliaacidrain.listener;
 
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.addons.skylliaacidrain.event.EntityDamageAcidEvent;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skylliaacidrain.SkylliaAcidRain;
-import net.kyori.adventure.text.minimessage.MiniMessage;
+import fr.euphyllia.skylliaacidrain.configuration.AcidConfigLoader;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import net.kyori.adventure.text.Component;
+import org.bukkit.*;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AcidListener implements Listener {
 
     private final SkylliaAcidRain plugin;
-    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+
+    private final Map<UUID, LivingEntity> trackedEntities = new ConcurrentHashMap<>();
+    private final Map<UUID, ScheduledTask> acidTasks = new ConcurrentHashMap<>();
 
     public AcidListener(SkylliaAcidRain plugin) {
         this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onEntityAddWorldEvent(final EntityAddToWorldEvent event) {
+        final World world = event.getWorld();
+        if (!SkylliaAPI.isWorldSkyblock(world)) {
+            return;
+        }
+
+        final Entity entity = event.getEntity();
+        if (AcidConfigLoader.config.isOnlyPlayer() && !(entity instanceof Player)) {
+            return;
+        }
+
+        if (!(entity instanceof LivingEntity livingEntity)) {
+            return;
+        }
+
+        startTask(livingEntity);
+    }
+
+    public void restartAllTasks() {
+        for (Map.Entry<UUID, ScheduledTask> entry : acidTasks.entrySet()) {
+            ScheduledTask task = entry.getValue();
+            task.cancel();
+        }
+        acidTasks.clear();
+
+        for (Map.Entry<UUID, LivingEntity> entry : trackedEntities.entrySet()) {
+            UUID uuid = entry.getKey();
+            LivingEntity entity = entry.getValue();
+            if (entity == null) {
+                trackedEntities.remove(uuid);
+                return;
+            }
+            entity.getScheduler().run(plugin, scheduledTask -> {
+                if (!entity.isDead() && entity.isValid()) {
+                    startTask(entity);
+                } else {
+                    trackedEntities.remove(uuid);
+                }
+            }, () -> trackedEntities.remove(uuid));
+        }
+    }
+
+    @EventHandler
+    public void onEntityRemoveWorldEvent(final EntityRemoveFromWorldEvent event) {
+        final World world = event.getWorld();
+        if (!SkylliaAPI.isWorldSkyblock(world)) {
+            return;
+        }
+        final Entity entity = event.getEntity();
+        if (AcidConfigLoader.config.isOnlyPlayer() && !(entity instanceof Player)) {
+            return;
+        }
+        if (!(entity instanceof LivingEntity livingEntity)) {
+            return;
+        }
+
+        stopTask(livingEntity.getUniqueId());
+    }
+
+    private void startTask(LivingEntity entity) {
+        UUID uuid = entity.getUniqueId();
+        long intervalMs = AcidConfigLoader.config.getDamageIntervalMs();
+
+        ScheduledTask task = entity.getScheduler().runAtFixedRate(
+                plugin,
+                scheduledTask -> handleAcidTick(entity),
+                null,
+                intervalMs,
+                intervalMs
+        );
+
+        if (task != null) {
+            trackedEntities.put(uuid, entity);
+            acidTasks.put(uuid, task);
+        }
+    }
+
+    private void stopTask(UUID uuid) {
+        ScheduledTask task = acidTasks.remove(uuid);
+        if (task != null) task.cancel();
+        trackedEntities.remove(uuid);
+    }
+
+
+    private void handleAcidTick(LivingEntity entity) {
+        if (entity.isDead()) {
+            return;
+        }
+
+        if (entity instanceof Player player) {
+            if (player.getGameMode() == GameMode.CREATIVE
+                    || player.getGameMode() == GameMode.SPECTATOR) return;
+        }
+
+        boolean inWater = entity.isInWater();
+        boolean inRain = entity.isInRain();
+
+        if (!inWater && !inRain) return;
+
+        applyAcidEffects(entity, inWater);
+    }
+
+    private void applyAcidEffects(LivingEntity entity, boolean inWater) {
+        double damage = AcidConfigLoader.config.getDamage();
+
+        EntityDamageAcidEvent acidEvent = new EntityDamageAcidEvent(entity, damage, inWater);
+        acidEvent.callEvent();
+        if (acidEvent.isCancelled()) return;
+
+        entity.damage(acidEvent.getDamage());
+
+        if (AcidConfigLoader.config.isPoisonEnabled()) {
+            entity.addPotionEffect(new PotionEffect(PotionEffectType.POISON,
+                    AcidConfigLoader.config.getPoisonDuration(),
+                    AcidConfigLoader.config.getPoisonAmplifier(),
+                    false, true, true));
+        }
+        if (AcidConfigLoader.config.isSlownessEnabled()) {
+            entity.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS,
+                    AcidConfigLoader.config.getSlownessDuration(),
+                    AcidConfigLoader.config.getSlownessAmplifier(),
+                    false, true, true));
+        }
+        if (AcidConfigLoader.config.isNauseaEnabled()) {
+            entity.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA,
+                    AcidConfigLoader.config.getNauseaDuration(),
+                    AcidConfigLoader.config.getNauseaAmplifier(),
+                    false, true, true));
+        }
+
+        if (AcidConfigLoader.config.isParticles()) {
+            entity.getWorld().spawnParticle(Particle.SPLASH, entity.getLocation().add(0, 1.0, 0), 20, 0.3, 0.5, 0.3, 0.05);
+            entity.getWorld().spawnParticle(Particle.DRIPPING_WATER, entity.getLocation().add(0, 1.8, 0), 8, 0.2, 0.1, 0.2, 0.0);
+        }
+
+        if (AcidConfigLoader.config.isSound()) {
+            try {
+                final NamespacedKey key = NamespacedKey.fromString(AcidConfigLoader.config.getSoundName().toLowerCase(Locale.ROOT));
+                Sound sound;
+
+                if (key != null) {
+                    sound = Bukkit.getUnsafe().get(RegistryKey.SOUND_EVENT, key);
+                    if (sound != null) {
+                        entity.getWorld().playSound(entity.getLocation(), sound, SoundCategory.HOSTILE, 0.6f, 0.8f);
+                    }
+                }
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        if (entity instanceof Player player) {
+            Component msg = inWater
+                    ? ConfigLoader.language.translate(player, "addons.acid-island.water-contact")
+                    : ConfigLoader.language.translate(player, "addons.acid-island.rain-contact");
+            player.sendActionBar(msg);
+        }
     }
 }

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
@@ -97,7 +97,7 @@ public class AcidListener implements Listener {
 
     private void startTask(LivingEntity entity) {
         UUID uuid = entity.getUniqueId();
-        long intervalTick = AcidConfigLoader.config.getDamageIntervalMs();
+        long intervalTick = AcidConfigLoader.config.getDamageIntervalTick();
 
         ScheduledTask task = entity.getScheduler().runAtFixedRate(
                 plugin,

--- a/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
+++ b/addons/SkylliaAcidRain/src/main/java/fr/euphyllia/skylliaacidrain/listener/AcidListener.java
@@ -1,0 +1,15 @@
+package fr.euphyllia.skylliaacidrain.listener;
+
+import fr.euphyllia.skylliaacidrain.SkylliaAcidRain;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.event.Listener;
+
+public class AcidListener implements Listener {
+
+    private final SkylliaAcidRain plugin;
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+
+    public AcidListener(SkylliaAcidRain plugin) {
+        this.plugin = plugin;
+    }
+}

--- a/addons/SkylliaAcidRain/src/main/resources/paper-plugin.yml
+++ b/addons/SkylliaAcidRain/src/main/resources/paper-plugin.yml
@@ -1,0 +1,18 @@
+name: SkylliaAcidRain
+version: ${version}
+main: fr.euphyllia.skylliaacidrain.SkylliaAcidRain
+api-version: 1.20.1
+folia-supported: true
+
+dependencies:
+  server:
+    Skyllia:
+      load: BEFORE
+      required: true
+      join-classpath: true
+
+commands:
+  acidrain:
+    description: Commandes admin de SkylliaAcidRain
+    usage: /acidrain <reload>
+    permission: skyllia.acidrain.admin

--- a/api/src/main/java/fr/euphyllia/skyllia/api/SkylliaAPI.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/SkylliaAPI.java
@@ -1,6 +1,7 @@
 package fr.euphyllia.skyllia.api;
 
 import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
+import fr.euphyllia.skyllia.api.configuration.IConfigRegistry;
 import fr.euphyllia.skyllia.api.database.IslandCustomDataQuery;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
@@ -316,5 +317,17 @@ public final class SkylliaAPI {
      */
     public static FlagModuleManager getFlagModuleManager() {
         return implementation.getFlagModuleManager();
+    }
+
+
+    /**
+     * Retrieves the configuration registry.
+     * Addons can register their {@link fr.euphyllia.skyllia.api.configuration.IConfigurationProvider}
+     * to participate in Skyllia's global reload cycle.
+     *
+     * @return The IConfigRegistry instance.
+     */
+    public static IConfigRegistry getConfigRegistry() {
+        return implementation.getConfigRegistry();
     }
 }

--- a/api/src/main/java/fr/euphyllia/skyllia/api/SkylliaImplementation.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/SkylliaImplementation.java
@@ -1,6 +1,7 @@
 package fr.euphyllia.skyllia.api;
 
 import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
+import fr.euphyllia.skyllia.api.configuration.IConfigRegistry;
 import fr.euphyllia.skyllia.api.database.IslandCustomDataQuery;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
@@ -220,4 +221,13 @@ public interface SkylliaImplementation {
      * @return The IslandCustomDataQuery implementation for database operations.
      */
     IslandCustomDataQuery getIslandCustomDataQuery();
+
+    /**
+     * Retrieves the configuration registry.
+     * Addons can use this to register their own {@link fr.euphyllia.skyllia.api.configuration.IConfigurationProvider}
+     * so they participate in Skyllia's global reload cycle.
+     *
+     * @return The IConfigRegistry instance.
+     */
+    IConfigRegistry getConfigRegistry();
 }

--- a/api/src/main/java/fr/euphyllia/skyllia/api/addons/skylliaacidrain/event/EntityDamageAcidEvent.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/addons/skylliaacidrain/event/EntityDamageAcidEvent.java
@@ -1,0 +1,95 @@
+package fr.euphyllia.skyllia.api.addons.skylliaacidrain.event;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a {@link LivingEntity} is about to receive acid damage
+ * from water or rain in a Skyblock world.
+ *
+ * <p>This event is fired by the <b>SkylliaAcidRain</b> addon before any
+ * damage or potion effects are applied to the entity.</p>
+ *
+ * <p>Cancelling this event prevents damage and potion effects from being applied.
+ * Particles, sounds, and the ActionBar message are unaffected by cancellation.</p>
+ *
+ * <p>The damage amount can also be modified via {@link #setDamage(double)}
+ * without cancelling the event entirely.</p>
+ *
+ */
+public class EntityDamageAcidEvent extends EntityEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private double damage;
+    private final boolean inWater;
+    private boolean cancelled;
+
+    public EntityDamageAcidEvent(@NotNull LivingEntity entity, double damage, boolean inWater) {
+        super(entity);
+        this.damage = damage;
+        this.inWater = inWater;
+        this.cancelled = false;
+    }
+
+    /**
+     * Returns the living entity receiving acid damage.
+     */
+    @Override
+    public @NotNull LivingEntity getEntity() {
+        return (LivingEntity) super.getEntity();
+    }
+
+    /**
+     * Gets the amount of damage that will be dealt.
+     */
+    public double getDamage() {
+        return damage;
+    }
+
+    /**
+     * Sets the amount of damage to deal. Set to 0 or below to cancel damage only.
+     */
+    public void setDamage(double damage) {
+        this.damage = damage;
+    }
+
+    /**
+     * Returns true if the entity is in water, false if exposed to acid rain.
+     */
+    public boolean isInWater() {
+        return inWater;
+    }
+
+    /**
+     * Returns true if the entity is exposed to acid rain (not water).
+     */
+    public boolean isInRain() {
+        return !inWater;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Cancels the event — no damage, no potion effects will be applied.
+     */
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/api/src/main/java/fr/euphyllia/skyllia/api/configuration/IConfigRegistry.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/configuration/IConfigRegistry.java
@@ -1,0 +1,29 @@
+package fr.euphyllia.skyllia.api.configuration;
+
+/**
+ * Allows external addons to register their own {@link IConfigurationProvider}
+ * into Skyllia's global configuration system.
+ *
+ * <p>Registered providers will be reloaded automatically when
+ * {@code ConfigLoader#reloadConfigs()} is called (e.g. via /skyllia reload).</p>
+ *
+ * <p>The implementation is held by {@code ConfigLoader} and exposed
+ * through {@link fr.euphyllia.skyllia.api.SkylliaAPI#getConfigRegistry()}.</p>
+ */
+public interface IConfigRegistry {
+
+    /**
+     * Register a configuration provider so it participates in global reloads.
+     *
+     * @param provider the provider to register
+     */
+    void registerConfig(IConfigurationProvider provider);
+
+    /**
+     * Unregister a previously registered provider.
+     * Should be called in the addon's {@code onDisable()}.
+     *
+     * @param provider the provider to remove
+     */
+    void unregisterConfig(IConfigurationProvider provider);
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,7 @@ modrinth {
             project(":addons:SkylliaBank").tasks.named("shadowJar"),
             project(":addons:SkylliaChallenge").tasks.named("shadowJar"),
             project(":addons:SkylliaChest").tasks.named("shadowJar"),
+            project(":addons:SkylliaAcidRain").tasks.named("shadowJar"),
         )
     )
 
@@ -184,5 +185,7 @@ tasks.modrinth {
         ":addons:SkylliaChat:shadowJar",
         ":addons:SkylliaBank:shadowJar",
         ":addons:SkylliaChallenge:shadowJar",
+        ":addons:SkylliaChest:shadowJar",
+        ":addons:SkylliaAcidRain:shadowJar",
     )
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/configuration/ConfigLoader.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/configuration/ConfigLoader.java
@@ -1,6 +1,7 @@
 package fr.euphyllia.skyllia.configuration;
 
 import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import fr.euphyllia.skyllia.api.configuration.IConfigRegistry;
 import fr.euphyllia.skyllia.api.configuration.IConfigurationProvider;
 import fr.euphyllia.skyllia.configuration.manager.*;
 import org.apache.logging.log4j.Level;
@@ -11,10 +12,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ConfigLoader {
+public class ConfigLoader implements IConfigRegistry {
 
     private static final Logger logger = LogManager.getLogger(ConfigLoader.class);
     private static final List<IConfigurationProvider> configManagers = new ArrayList<>();
+
+    public static final ConfigLoader INSTANCE = new ConfigLoader();
 
     public static GeneralConfigManager general;
     public static DatabaseConfigManager database;
@@ -75,6 +78,18 @@ public class ConfigLoader {
         CommentedFileConfig configFile = CommentedFileConfig.builder(file).sync().autosave().build();
         configFile.load();
         return configFile;
+    }
+
+    @Override
+    public void registerConfig(IConfigurationProvider provider) {
+        if (!configManagers.contains(provider)) {
+            configManagers.add(provider);
+        }
+    }
+
+    @Override
+    public void unregisterConfig(IConfigurationProvider provider) {
+        configManagers.remove(provider);
     }
 
     public static void reloadConfigs() {

--- a/plugin/src/main/java/fr/euphyllia/skyllia/managers/skyblock/APISkyllia.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/managers/skyblock/APISkyllia.java
@@ -4,6 +4,7 @@ import fr.euphyllia.skyllia.api.InterneAPI;
 import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skyllia.api.SkylliaImplementation;
 import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
+import fr.euphyllia.skyllia.api.configuration.IConfigRegistry;
 import fr.euphyllia.skyllia.api.database.IslandCustomDataQuery;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
@@ -16,6 +17,7 @@ import fr.euphyllia.skyllia.api.skyblock.model.Position;
 import fr.euphyllia.skyllia.api.utils.nms.BiomesImpl;
 import fr.euphyllia.skyllia.api.utils.nms.MobsSpawnImpl;
 import fr.euphyllia.skyllia.api.utils.nms.WorldNMS;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.utils.WorldUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -230,6 +232,10 @@ public final class APISkyllia implements SkylliaImplementation {
         return this.interneAPI.getIslandQuery().getIslandCustomDataQuery();
     }
 
+    @Override
+    public IConfigRegistry getConfigRegistry() {
+        return ConfigLoader.INSTANCE;
+    }
 
     private double[] append(double[] arr, double element) {
         double[] newArr = new double[arr.length + 1];

--- a/plugin/src/main/resources/language/en_GB.toml
+++ b/plugin/src/main/resources/language/en_GB.toml
@@ -403,3 +403,7 @@ failure = "<red>An error occurred while adding %amount% to the island's account 
 no-permission = "<red>You do not have permission to open the island chest.</red>"
 inventory-title = "<gold>%island_name%'s Island Chest</gold>"
 open = "<green>You have opened the island chest.</green>"
+
+[addons.acid-island]
+water-contact = "<red>⚠ Acidic water burns you !</red>"
+rain-contact = "<dark_aqua>☔ Acid rain is eating away at your skin !</dark_aqua>"

--- a/plugin/src/main/resources/language/en_US.toml
+++ b/plugin/src/main/resources/language/en_US.toml
@@ -80,7 +80,7 @@ failed = "<red>Database update failed.</red>"
 usage = """<gray>Usage:</gray> <light_purple>/is flag list [filter]</light_purple>
 <gray> - </gray><light_purple>/is flag <namespace:key> [true|false]</light_purple>
 <gray> - </gray><light_purple>/is flag toggle <namespace:key></light_purple>
-<gray> - </gray><light_purple>/is flag set <namespace:key> <true|false></light_purple>""""
+<gray> - </gray><light_purple>/is flag set <namespace:key> <true|false></light_purple>"""
 value = "<white>%flag%</white> <gray>=</gray> <aqua>%value%</aqua>"
 
 [island.flag.flag]
@@ -400,3 +400,7 @@ failure = "<red>An error occurred while adding %amount% to the island's account 
 no-permission = "<red>You do not have permission to open the island chest.</red>"
 inventory-title = "<gold>%island_name%'s Island Chest</gold>"
 open = "<green>You have opened the island chest.</green>"
+
+[addons.acid-island]
+water-contact = "<red>⚠ Acidic water burns you !</red>"
+rain-contact = "<dark_aqua>☔ Acid rain is eating away at your skin !</dark_aqua>"

--- a/plugin/src/main/resources/language/fr_FR.toml
+++ b/plugin/src/main/resources/language/fr_FR.toml
@@ -399,3 +399,7 @@ failure = "<red>Une erreur s'est produite lors de l'ajout de %amount% dans le co
 no-permission = "<red>Votre rang ne vous permet pas d'utiliser ce coffre."
 inventory-title = "<gold>=== Coffre de l'île de %island_name% ===</gold>"
 open = "<green>Vous avez ouvert le coffre de l'île.</green>"
+
+[addons.acid-island]
+water-contact = "<red>⚠ L'eau acide vous brûle !</red>"
+rain-contact = "<dark_aqua>☔ La pluie acide vous ronge la peau !</dark_aqua>"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include("addons:SkylliaChat")
 include("addons:SkylliaBank")
 include("addons:SkylliaChallenge")
 include("addons:SkylliaChest")
+include("addons:SkylliaAcidRain")
 // Hook
 include("hook:worldedit")
 include("hook:fastasyncworldedit")


### PR DESCRIPTION
This addon allows you to:

Take damage if you are in the rain
Take damage if you are in water

You can configure:
- Damage per tick
- Add a poison effect
- Add a slowness effect
- Add a nausea effect

An event: fr.euphyllia.skyllia.api.addons.skylliaacidrain.event.EntityDamageAcidEvent allows you to choose which damage the player will take.