### PR TITLE
Réécriture des Placeholders

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,7 +7,8 @@ group = "fr.euphyllia.skyllia"
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT") { isTransitive = false }
-    compileOnly("net.kyori:adventure-text-minimessage:4.25.0")
+    compileOnly("net.kyori:adventure-text-minimessage:4.26.1")
+    compileOnly("net.kyori:adventure-text-serializer-legacy:4.26.1")
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("dev.faststats.metrics:bukkit:0.18.1")
     compileOnly(project(":api"))

--- a/plugin/src/main/java/fr/euphyllia/skyllia/SkylliaLoader.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/SkylliaLoader.java
@@ -21,7 +21,8 @@ public class SkylliaLoader implements PluginLoader {
         // Maven Repository Dependencies
         resolver.addDependency(new Dependency(new DefaultArtifact("org.apache.logging.log4j:log4j-core:2.25.3"), null));
         resolver.addDependency(new Dependency(new DefaultArtifact("org.apache.logging.log4j:log4j-api:2.25.3"), null));
-        resolver.addDependency(new Dependency(new DefaultArtifact("net.kyori:adventure-text-minimessage:4.20.0"), null));
+        resolver.addDependency(new Dependency(new DefaultArtifact("net.kyori:adventure-text-minimessage:4.26.1"), null));
+        resolver.addDependency(new Dependency(new DefaultArtifact("net.kyori:adventure-text-serializer-legacy:4.26.1"), null));
         resolver.addDependency(new Dependency(new DefaultArtifact("com.electronwill.night-config:toml:3.8.3"), null));
 
         // HikariCP dependency

--- a/plugin/src/main/java/fr/euphyllia/skyllia/configuration/manager/LanguageConfigManager.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/configuration/manager/LanguageConfigManager.java
@@ -14,6 +14,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.InputStream;
@@ -210,4 +212,20 @@ public class LanguageConfigManager implements IConfigurationProvider {
         sender.sendMessage(translate(key, Map.of()));
     }
 
+    public @Nullable String translateRaw(@NotNull Locale locale, String key,  @NotNull Map<String, String> placeholders) {
+        Map<String, String> langMessages = translations.get(locale);
+        if (langMessages == null) {
+            langMessages = translations.get(defaultLocale);
+        }
+
+        String message = (langMessages != null)
+                ? langMessages.getOrDefault(key, "<red>Missing translation: " + key + "</red>")
+                : "<red>Missing translation: " + key + "</red>";
+
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            message = message.replace(entry.getKey(), entry.getValue());
+        }
+
+        return message;
+    }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/SkylliaExpansion.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/SkylliaExpansion.java
@@ -2,55 +2,64 @@ package fr.euphyllia.skyllia.papi;
 
 import fr.euphyllia.skyllia.Skyllia;
 import fr.euphyllia.skyllia.api.SkylliaAPI;
-import fr.euphyllia.skyllia.api.permissions.FlagId;
-import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
-import fr.euphyllia.skyllia.api.permissions.PermissionId;
-import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.skyblock.Island;
-import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import fr.euphyllia.skyllia.papi.handlers.*;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Locale;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+/**
+ * PlaceholderAPI expansion for Skyllia.
+ *
+ * <p>Acts as a pure router: it resolves the island for the requesting player,
+ * strips the placeholder prefix, and delegates to the appropriate
+ * {@link PlaceholderHandler}. No business logic lives here.
+ *
+ * <p>To add a new placeholder group, implement {@link PlaceholderHandler}
+ * and register it in {@link #buildHandlerRegistry()}.
+ */
 public class SkylliaExpansion extends PlaceholderExpansion {
-
 
     private final Skyllia plugin;
 
-    public SkylliaExpansion(Skyllia skyllia) {
+    private final Map<String, PlaceholderHandler> handlers;
+
+    public SkylliaExpansion(@NotNull Skyllia skyllia) {
         this.plugin = skyllia;
+        this.handlers = buildHandlerRegistry();
     }
 
-    private static @NotNull RoleType resolveRole(Island island, UUID playerId) {
-        var member = island.getMember(playerId);
-        if (member == null) {
-            return RoleType.VISITOR;
+    /**
+     * Registers all placeholder handlers.
+     * Add new entries here when creating a new handler.
+     */
+    private static Map<String, PlaceholderHandler> buildHandlerRegistry() {
+        List<PlaceholderHandler> allHandlers = List.of(
+                new IslandHandler(),
+                new FlagsHandler(),
+                new PermissionsHandler(),
+                new BannedHandler(),
+                new MembersHandler(),
+                // Legacy alias: gamerule_* → same handler as flags_*
+                new FlagsHandler() {
+                    @Override
+                    public @NotNull String prefix() {
+                        return "gamerule";
+                    }
+                }
+        );
+
+        Map<String, PlaceholderHandler> registry = new HashMap<>();
+        for (PlaceholderHandler handler : allHandlers) {
+            registry.put(handler.prefix() + "_", handler);
         }
-        RoleType role = member.getRoleType();
-        return role != null ? role : RoleType.VISITOR;
-    }
-
-    private static @Nullable RoleType parseRole(String input) {
-        if (input == null || input.isEmpty()) return null;
-        try {
-            return RoleType.valueOf(input.toUpperCase(Locale.ROOT));
-        } catch (Exception ignored) {
-            return null;
-        }
-    }
-
-    private static @Nullable NamespacedKey parseKeyLenient(String input) {
-        if (input == null || input.isEmpty()) return null;
-
-        NamespacedKey key = NamespacedKey.fromString(input);
-        if (key != null) return key;
-
-        return NamespacedKey.fromString("skyllia:" + input);
+        return Map.copyOf(registry);
     }
 
     @Override
@@ -80,87 +89,22 @@ public class SkylliaExpansion extends PlaceholderExpansion {
 
     @Nullable
     @Override
-    public String onRequest(final OfflinePlayer player, @NotNull final String placeholder) {
-        UUID offlinePlayerUUID = player.getUniqueId();
+    public String onRequest(@NotNull OfflinePlayer player, @NotNull String placeholder) {
+        UUID playerId = player.getUniqueId();
 
-        Island island = SkylliaAPI.getIslandByPlayerId(offlinePlayerUUID);
-        if (island == null) {
-            return null;
-        }
+        Island island = SkylliaAPI.getIslandByPlayerId(playerId);
+        if (island == null) return null;
 
-        String placeholderLower = placeholder.toLowerCase();
-        if (placeholderLower.startsWith("island_")) {
-            return processIsland(island, offlinePlayerUUID, placeholderLower);
-        }
+        String lowerPlaceholder = placeholder.toLowerCase();
 
-        if (placeholderLower.startsWith("permissions_")) {
-            return processPermissions(island, offlinePlayerUUID, placeholderLower);
-        }
-
-        if (placeholderLower.startsWith("flags_")) {
-            return processFlags(island, placeholder.substring("flags_".length()));
-        }
-
-        if (placeholderLower.startsWith("gamerule_")) { // ancien nom
-            return processFlags(island, placeholder.substring("gamerule_".length()));
+        for (Map.Entry<String, PlaceholderHandler> entry : handlers.entrySet()) {
+            String prefix = entry.getKey();   // e.g. "island_"
+            if (lowerPlaceholder.startsWith(prefix)) {
+                String key = lowerPlaceholder.substring(prefix.length());
+                return entry.getValue().handle(player, island, key);
+            }
         }
 
         return null;
-    }
-
-    private String processIsland(Island island, UUID playerId, String placeholder) {
-        RoleType role = resolveRole(island, playerId);
-
-        return switch (placeholder) {
-            case "island_size" -> String.valueOf(island.getSize());
-            case "island_members_max_size" -> String.valueOf(island.getMaxMembers());
-            case "island_members_size" -> String.valueOf(island.getMembers().size());
-            case "island_role", "island_rank" -> role.name();
-            case "island_role_value" -> String.valueOf(role.getValue());
-            default -> null;
-        };
-    }
-
-    private String processPermissions(Island island, UUID playerId, String placeholder) {
-        PermissionRegistry registry = SkylliaAPI.getPermissionRegistry();
-        String rest = placeholder.substring("permissions_".length());
-
-        RoleType role;
-        String keyPart;
-
-        if (rest.startsWith("role_")) {
-            String tmp = rest.substring("role_".length());
-            int idx = tmp.indexOf('_');
-            if (idx <= 0) return null;
-
-            String roleStr = tmp.substring(0, idx);
-            keyPart = tmp.substring(idx + 1);
-
-            role = parseRole(roleStr);
-            if (role == null) return null;
-        } else {
-            role = resolveRole(island, playerId);
-            keyPart = rest;
-        }
-        NamespacedKey key = parseKeyLenient(keyPart);
-        if (key == null) return null;
-
-        PermissionId pid = registry.getIfPresent(key);
-        if (pid == null) return null;
-
-        boolean allowed = island.getCompiledPermissions().has(registry, role, pid);
-        return String.valueOf(allowed);
-    }
-
-    private String processFlags(Island island, String keyPart) {
-        IslandFlagRegistry registry = SkylliaAPI.getFlagRegistry();
-
-        NamespacedKey key = parseKeyLenient(keyPart);
-        if (key == null) return null;
-
-        FlagId fid = registry.getIfPresent(key);
-        if (fid == null) return null;
-
-        return String.valueOf(island.getIslandFlags().has(registry, fid));
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/SkylliaExpansion.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/SkylliaExpansion.java
@@ -46,6 +46,7 @@ public class SkylliaExpansion extends PlaceholderExpansion {
                 new PermissionsHandler(),
                 new BannedHandler(),
                 new MembersHandler(),
+                new WarpHandler(),
                 // Legacy alias: gamerule_* → same handler as flags_*
                 new FlagsHandler() {
                     @Override

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/SkylliaPAPIUtils.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/SkylliaPAPIUtils.java
@@ -1,0 +1,72 @@
+package fr.euphyllia.skyllia.papi;
+
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import org.bukkit.NamespacedKey;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Shared utility methods for the Skyllia PlaceholderAPI expansion.
+ */
+public final class SkylliaPAPIUtils {
+
+    private SkylliaPAPIUtils() {
+    }
+
+    /**
+     * Resolves the {@link RoleType} of a player on a given island.
+     * Returns {@link RoleType#VISITOR} if the player is not a member.
+     */
+    public static @NotNull RoleType resolveRole(@NotNull Island island, @NotNull UUID playerId) {
+        var member = island.getMember(playerId);
+        if (member == null) return RoleType.VISITOR;
+        RoleType role = member.getRoleType();
+        return role != null ? role : RoleType.VISITOR;
+    }
+
+    /**
+     * Parses a role name (case-insensitive) into a {@link RoleType}.
+     *
+     * @return the matching role, or {@code null} if the input is invalid.
+     */
+    public static @Nullable RoleType parseRole(@Nullable String input) {
+        if (input == null || input.isEmpty()) return null;
+        try {
+            return RoleType.valueOf(input.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Parses a namespaced key leniently: tries the raw input first,
+     * then prepends the {@code skyllia:} namespace as a fallback.
+     *
+     * @return a valid {@link NamespacedKey}, or {@code null} if the input is invalid.
+     */
+    public static @Nullable NamespacedKey parseKeyLenient(@Nullable String input) {
+        if (input == null || input.isEmpty()) return null;
+        NamespacedKey key = NamespacedKey.fromString(input);
+        if (key != null) return key;
+        return NamespacedKey.fromString("skyllia:" + input);
+    }
+
+    /**
+     * Parses a non-negative integer index from a string.
+     *
+     * @return the parsed index, or {@code -1} if the input is invalid or negative.
+     */
+    public static int parseIndex(@Nullable String s) {
+        if (s == null) return -1;
+        try {
+            int v = Integer.parseInt(s);
+            return v >= 0 ? v : -1;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/BannedHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/BannedHandler.java
@@ -1,0 +1,64 @@
+package fr.euphyllia.skyllia.papi.handlers;
+
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.Players;
+import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Handles {@code %skyllia_banned_*%} placeholders.
+ * Exposes the island's banned player list as indexed entries,
+ * suitable for rendering dynamic GUIs in DeluxeMenus.
+ *
+ * <table>
+ *   <tr><th>Placeholder</th><th>Returns</th></tr>
+ *   <tr><td>banned_count</td><td>Total number of banned players</td></tr>
+ *   <tr><td>banned_has_&lt;N&gt;</td><td>{@code true} if index N exists, otherwise {@code false}</td></tr>
+ *   <tr><td>banned_name_&lt;N&gt;</td><td>Last known name of banned player at index N</td></tr>
+ *   <tr><td>banned_uuid_&lt;N&gt;</td><td>UUID of banned player at index N</td></tr>
+ * </table>
+ * <p>
+ * Indices are zero-based. Out-of-range name/uuid requests return an empty string.
+ */
+public class BannedHandler implements PlaceholderHandler {
+
+    @Override
+    public @NotNull String prefix() {
+        return "banned";
+    }
+
+    @Override
+    public @Nullable String handle(@NotNull OfflinePlayer player,
+                                   @NotNull Island island,
+                                   @NotNull String key) {
+        List<Players> banned = island.getBannedMembers();
+
+        if (key.equals("count")) {
+            return String.valueOf(banned.size());
+        }
+
+        if (key.startsWith("has_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("has_".length()));
+            if (index < 0) return null;
+            return String.valueOf(index < banned.size());
+        }
+
+        if (key.startsWith("name_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("name_".length()));
+            if (index < 0 || index >= banned.size()) return "";
+            return banned.get(index).getLastKnowName();
+        }
+
+        if (key.startsWith("uuid_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("uuid_".length()));
+            if (index < 0 || index >= banned.size()) return "";
+            return banned.get(index).getMojangId().toString();
+        }
+
+        return null;
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/FlagsHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/FlagsHandler.java
@@ -2,29 +2,58 @@ package fr.euphyllia.skyllia.papi.handlers;
 
 import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skyllia.api.permissions.FlagId;
+import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+import java.util.Map;
+
 /**
  * Handles {@code %skyllia_flags_*%} placeholders.
  * Also registered under the legacy prefix {@code gamerule_}.
  *
- * <table>
- *   <tr><th>Placeholder</th><th>Returns</th></tr>
- *   <tr><td>flags_&lt;flag_key&gt;</td><td>{@code true} / {@code false}</td></tr>
- *   <tr><td>gamerule_&lt;flag_key&gt;</td><td>Same (legacy alias)</td></tr>
- * </table>
- * <p>
- * The flag key may be a full namespaced key ({@code skyllia:pvp})
+ * <p><b>Value placeholders</b> — return {@code "true"} or {@code "false"}:
+ * <ul>
+ *   <li>{@code flags_<flag_key>} — current value of the flag on the island.</li>
+ *   <li>{@code gamerule_<flag_key>} — same (legacy alias).</li>
+ * </ul>
+ *
+ * <p><b>Metadata placeholders</b> — return the translated display string:
+ * <ul>
+ *   <li>{@code flags_name_<flag_key>} — display name of the flag.</li>
+ *   <li>{@code flags_desc_<flag_key>} — description of the flag.</li>
+ * </ul>
+ *
+ * <p>The flag key may be a full namespaced key ({@code skyllia:pvp})
  * or a bare name ({@code pvp}) — the {@code skyllia:} namespace is
  * prepended automatically as a fallback.
+ *
+ * <p><b>Rendering strategy for metadata:</b>
+ * <ul>
+ *   <li>If {@code use_adventure_provided_replacer=true} in PlaceholderAPI's config,
+ *       the raw MiniMessage string is returned directly — Adventure will render it.</li>
+ *   <li>Otherwise, the Component is serialized to legacy {@code §}-codes so that
+ *       plugins like DeluxeMenus can display colors correctly.</li>
+ * </ul>
  */
 public class FlagsHandler implements PlaceholderHandler {
+
+    private final boolean adventureReplacer;
+
+    public FlagsHandler() {
+        this.adventureReplacer = PlaceholderAPIPlugin.getInstance()
+                .getConfig()
+                .getBoolean("use_adventure_provided_replacer", false);
+    }
 
     @Override
     public @NotNull String prefix() {
@@ -36,6 +65,14 @@ public class FlagsHandler implements PlaceholderHandler {
                                    @NotNull Island island,
                                    @NotNull String key) {
         IslandFlagRegistry registry = SkylliaAPI.getFlagRegistry();
+        Locale locale = resolveLocale(player);
+
+        if (key.startsWith("name_")) {
+            return resolveNodeMeta(registry, key.substring("name_".length()), MetaType.NAME, locale);
+        }
+        if (key.startsWith("desc_")) {
+            return resolveNodeMeta(registry, key.substring("desc_".length()), MetaType.DESCRIPTION, locale);
+        }
 
         NamespacedKey namespacedKey = SkylliaPAPIUtils.parseKeyLenient(key);
         if (namespacedKey == null) return null;
@@ -44,5 +81,46 @@ public class FlagsHandler implements PlaceholderHandler {
         if (fid == null) return null;
 
         return String.valueOf(island.getIslandFlags().has(registry, fid));
+    }
+
+    private enum MetaType { NAME, DESCRIPTION }
+
+    private static @NotNull Locale resolveLocale(@NotNull OfflinePlayer player) {
+        if (player.isOnline() && player.getPlayer() != null) {
+            return player.getPlayer().locale();
+        }
+        return Locale.getDefault();
+    }
+
+    /**
+     * Resolves the translated string for a flag metadata field.
+     * <p>
+     * If the Adventure replacer is active in PAPI, returns the raw MiniMessage string
+     * so Adventure can render it natively in the component pipeline.
+     * Otherwise, serializes the rendered {@code Component} to legacy §-codes for
+     * compatibility with plugins that only understand legacy formatting (e.g. DeluxeMenus).
+     */
+    private @Nullable String resolveNodeMeta(@NotNull IslandFlagRegistry registry,
+                                             @NotNull String rawKey,
+                                             @NotNull MetaType type,
+                                             @NotNull Locale locale) {
+        NamespacedKey namespacedKey = SkylliaPAPIUtils.parseKeyLenient(rawKey);
+        if (namespacedKey == null) return "";
+
+        FlagId fid = registry.getIfPresent(namespacedKey);
+        if (fid == null) return "";
+
+        FlagNode node = registry.node(fid);
+        String langKey = switch (type) {
+            case NAME        -> node.displayName();
+            case DESCRIPTION -> node.description();
+        };
+
+        if (adventureReplacer) {
+            return ConfigLoader.language.translateRaw(locale, langKey, Map.of());
+        } else {
+            return LegacyComponentSerializer.legacySection()
+                    .serialize(ConfigLoader.language.translate(locale, langKey, Map.of(), false));
+        }
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/FlagsHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/FlagsHandler.java
@@ -1,0 +1,48 @@
+package fr.euphyllia.skyllia.papi.handlers;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.permissions.FlagId;
+import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import org.bukkit.NamespacedKey;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Handles {@code %skyllia_flags_*%} placeholders.
+ * Also registered under the legacy prefix {@code gamerule_}.
+ *
+ * <table>
+ *   <tr><th>Placeholder</th><th>Returns</th></tr>
+ *   <tr><td>flags_&lt;flag_key&gt;</td><td>{@code true} / {@code false}</td></tr>
+ *   <tr><td>gamerule_&lt;flag_key&gt;</td><td>Same (legacy alias)</td></tr>
+ * </table>
+ * <p>
+ * The flag key may be a full namespaced key ({@code skyllia:pvp})
+ * or a bare name ({@code pvp}) — the {@code skyllia:} namespace is
+ * prepended automatically as a fallback.
+ */
+public class FlagsHandler implements PlaceholderHandler {
+
+    @Override
+    public @NotNull String prefix() {
+        return "flags";
+    }
+
+    @Override
+    public @Nullable String handle(@NotNull OfflinePlayer player,
+                                   @NotNull Island island,
+                                   @NotNull String key) {
+        IslandFlagRegistry registry = SkylliaAPI.getFlagRegistry();
+
+        NamespacedKey namespacedKey = SkylliaPAPIUtils.parseKeyLenient(key);
+        if (namespacedKey == null) return null;
+
+        FlagId fid = registry.getIfPresent(namespacedKey);
+        if (fid == null) return null;
+
+        return String.valueOf(island.getIslandFlags().has(registry, fid));
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/IslandHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/IslandHandler.java
@@ -1,0 +1,44 @@
+package fr.euphyllia.skyllia.papi.handlers;
+
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Handles {@code %skyllia_island_*%} placeholders.
+ *
+ * <table>
+ *   <tr><th>Placeholder</th><th>Returns</th></tr>
+ *   <tr><td>island_size</td><td>Island radius in blocks</td></tr>
+ *   <tr><td>island_members_size</td><td>Current member count</td></tr>
+ *   <tr><td>island_members_max_size</td><td>Maximum member slots</td></tr>
+ *   <tr><td>island_role / island_rank</td><td>Player's role name (e.g. OWNER)</td></tr>
+ *   <tr><td>island_role_value</td><td>Numeric value of the player's role</td></tr>
+ * </table>
+ */
+public class IslandHandler implements PlaceholderHandler {
+
+    @Override
+    public @NotNull String prefix() {
+        return "island";
+    }
+
+    @Override
+    public @Nullable String handle(@NotNull OfflinePlayer player,
+                                   @NotNull Island island,
+                                   @NotNull String key) {
+        RoleType role = SkylliaPAPIUtils.resolveRole(island, player.getUniqueId());
+
+        return switch (key) {
+            case "size" -> String.valueOf(island.getSize());
+            case "members_size" -> String.valueOf(island.getMembers().size());
+            case "members_max_size" -> String.valueOf(island.getMaxMembers());
+            case "role", "rank" -> role.name();
+            case "role_value" -> String.valueOf(role.getValue());
+            default -> null;
+        };
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/IslandHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/IslandHandler.java
@@ -1,7 +1,7 @@
 package fr.euphyllia.skyllia.papi.handlers;
 
 import fr.euphyllia.skyllia.api.skyblock.Island;
-import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import fr.euphyllia.skyllia.api.skyblock.Players;
 import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
@@ -11,15 +11,47 @@ import org.jetbrains.annotations.Nullable;
  * Handles {@code %skyllia_island_*%} placeholders.
  *
  * <table>
+ *   <caption>Available placeholders</caption>
  *   <tr><th>Placeholder</th><th>Returns</th></tr>
- *   <tr><td>island_size</td><td>Island radius in blocks</td></tr>
+ * <p>
+ *   <tr><td colspan="2"><b>— Identity —</b></td></tr>
+ *   <tr><td>island_id</td><td>Island UUID</td></tr>
+ *   <tr><td>island_owner_name</td><td>Owner's last known name</td></tr>
+ *   <tr><td>island_owner_uuid</td><td>Owner's UUID</td></tr>
+ *   <tr><td>island_create_date</td><td>Creation date (Timestamp.toString)</td></tr>
+ * <p>
+ *   <tr><td colspan="2"><b>— Size —</b></td></tr>
+ *   <tr><td>island_size</td><td>Island radius in blocks (double)</td></tr>
+ *   <tr><td>island_size_int</td><td>Island radius rounded to int</td></tr>
  *   <tr><td>island_members_size</td><td>Current member count</td></tr>
  *   <tr><td>island_members_max_size</td><td>Maximum member slots</td></tr>
- *   <tr><td>island_role / island_rank</td><td>Player's role name (e.g. OWNER)</td></tr>
- *   <tr><td>island_role_value</td><td>Numeric value of the player's role</td></tr>
+ * <p>
+ *   <tr><td colspan="2"><b>— Role —</b></td></tr>
+ *   <tr><td>island_role / island_rank</td><td>Requesting player's role name (e.g. OWNER)</td></tr>
+ *   <tr><td>island_role_value</td><td>Numeric value of the requesting player's role</td></tr>
+ * <p>
+ *   <tr><td colspan="2"><b>— State —</b></td></tr>
+ *   <tr><td>island_access</td><td>{@code true} if private, {@code false} if public</td></tr>
+ *   <tr><td>island_disabled</td><td>{@code true} if the island is disabled</td></tr>
  * </table>
+ *
+ * <p>Warp-related placeholders are handled by {@link WarpHandler}.
  */
 public class IslandHandler implements PlaceholderHandler {
+
+    private static @NotNull String ownerName(@NotNull Island island) {
+        Players owner = island.getOwner();
+        return owner != null ? owner.getLastKnowName() : "";
+    }
+
+    private static @NotNull String ownerUuid(@NotNull Island island) {
+        Players owner = island.getOwner();
+        return owner != null ? owner.getMojangId().toString() : "";
+    }
+
+    private static @NotNull String createDate(@NotNull Island island) {
+        return island.getCreateDate() != null ? island.getCreateDate().toString() : "";
+    }
 
     @Override
     public @NotNull String prefix() {
@@ -30,15 +62,24 @@ public class IslandHandler implements PlaceholderHandler {
     public @Nullable String handle(@NotNull OfflinePlayer player,
                                    @NotNull Island island,
                                    @NotNull String key) {
-        RoleType role = SkylliaPAPIUtils.resolveRole(island, player.getUniqueId());
-
         return switch (key) {
+
+            case "id" -> island.getId().toString();
+            case "owner_name" -> ownerName(island);
+            case "owner_uuid" -> ownerUuid(island);
+            case "create_date" -> createDate(island);
+
             case "size" -> String.valueOf(island.getSize());
+            case "size_int" -> String.valueOf((int) island.getSize());
             case "members_size" -> String.valueOf(island.getMembers().size());
             case "members_max_size" -> String.valueOf(island.getMaxMembers());
-            case "role", "rank" -> role.name();
-            case "role_value" -> String.valueOf(role.getValue());
+
+            case "role", "rank" -> SkylliaPAPIUtils.resolveRole(island, player.getUniqueId()).name();
+            case "role_value" -> String.valueOf(SkylliaPAPIUtils.resolveRole(island, player.getUniqueId()).getValue());
+
             case "access" -> String.valueOf(island.isPrivateIsland());
+            case "disabled" -> String.valueOf(island.isDisable());
+
             default -> null;
         };
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/IslandHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/IslandHandler.java
@@ -38,6 +38,7 @@ public class IslandHandler implements PlaceholderHandler {
             case "members_max_size" -> String.valueOf(island.getMaxMembers());
             case "role", "rank" -> role.name();
             case "role_value" -> String.valueOf(role.getValue());
+            case "access" -> String.valueOf(island.isPrivateIsland());
             default -> null;
         };
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/MembersHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/MembersHandler.java
@@ -1,0 +1,68 @@
+package fr.euphyllia.skyllia.papi.handlers;
+
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.Players;
+import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Handles {@code %skyllia_member_*%} placeholders.
+ * Exposes the island's member list as indexed entries,
+ * suitable for rendering dynamic GUIs in DeluxeMenus.
+ *
+ * <table>
+ *   <tr><th>Placeholder</th><th>Returns</th></tr>
+ *   <tr><td>member_has_&lt;N&gt;</td><td>{@code true} if index N exists, otherwise {@code false}</td></tr>
+ *   <tr><td>member_name_&lt;N&gt;</td><td>Last known name of the member at index N</td></tr>
+ *   <tr><td>member_uuid_&lt;N&gt;</td><td>UUID of the member at index N</td></tr>
+ *   <tr><td>member_role_&lt;N&gt;</td><td>Role name of the member at index N</td></tr>
+ * </table>
+ * <p>
+ * Indices are zero-based. Out-of-range name/uuid/role requests return an empty string.
+ */
+public class MembersHandler implements PlaceholderHandler {
+
+    @Override
+    public @NotNull String prefix() {
+        return "member";
+    }
+
+    @Override
+    public @Nullable String handle(@NotNull OfflinePlayer player,
+                                   @NotNull Island island,
+                                   @NotNull String key) {
+        List<Players> members = island.getMembers();
+
+        if (key.startsWith("has_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("has_".length()));
+            if (index < 0) return null;
+            return String.valueOf(index < members.size());
+        }
+
+        if (key.startsWith("name_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("name_".length()));
+            if (index < 0 || index >= members.size()) return "";
+            return members.get(index).getLastKnowName();
+        }
+
+        if (key.startsWith("uuid_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("uuid_".length()));
+            if (index < 0 || index >= members.size()) return "";
+            return members.get(index).getMojangId().toString();
+        }
+
+        if (key.startsWith("role_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("role_".length()));
+            if (index < 0 || index >= members.size()) return "";
+            RoleType role = members.get(index).getRoleType();
+            return role != null ? role.name() : RoleType.MEMBER.name();
+        }
+
+        return null;
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/PermissionsHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/PermissionsHandler.java
@@ -2,28 +2,62 @@ package fr.euphyllia.skyllia.papi.handlers;
 
 import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skyllia.api.permissions.PermissionId;
+import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+import java.util.Map;
+
 /**
  * Handles {@code %skyllia_permissions_*%} placeholders.
  *
- * <p>Two forms are supported:
+ * <p><b>Value placeholders</b> — return {@code "true"} or {@code "false"}:
  * <ul>
- *   <li>{@code permissions_<perm_key>} — checks against the <em>requesting player's</em> role.</li>
- *   <li>{@code permissions_role_<ROLE>_<perm_key>} — checks against the specified role regardless
- *       of who is requesting (useful for displaying permission tables in GUIs).</li>
+ *   <li>{@code permissions_<perm_key>} — checks against the requesting player's role.</li>
+ *   <li>{@code permissions_role_<ROLE>_<perm_key>} — checks against the specified role
+ *       regardless of who is requesting (useful for permission tables in GUIs).</li>
  * </ul>
- * <p>
- * Both return {@code "true"} or {@code "false"}.
+ *
+ * <p><b>Metadata placeholders</b> — return the translated display string:
+ * <ul>
+ *   <li>{@code permissions_name_<perm_key>} — display name of the permission.</li>
+ *   <li>{@code permissions_desc_<perm_key>} — description of the permission.</li>
+ * </ul>
+ *
+ * <p><b>Rendering strategy for metadata:</b>
+ * <ul>
+ *   <li>If {@code use_adventure_provided_replacer=true} in PlaceholderAPI's config,
+ *       the raw MiniMessage string is returned directly — Adventure will render it.</li>
+ *   <li>Otherwise, the Component is serialized to legacy {@code §}-codes so that
+ *       plugins like DeluxeMenus can display colors correctly.</li>
+ * </ul>
  */
 public class PermissionsHandler implements PlaceholderHandler {
+
+    private final boolean adventureReplacer;
+
+    public PermissionsHandler() {
+        this.adventureReplacer = PlaceholderAPIPlugin.getInstance()
+                .getConfig()
+                .getBoolean("use_adventure_provided_replacer", false);
+    }
+
+    private static @NotNull Locale resolveLocale(@NotNull OfflinePlayer player) {
+        if (player.isOnline() && player.getPlayer() != null) {
+            return player.getPlayer().locale();
+        }
+        return Locale.getDefault();
+    }
 
     @Override
     public @NotNull String prefix() {
@@ -35,6 +69,14 @@ public class PermissionsHandler implements PlaceholderHandler {
                                    @NotNull Island island,
                                    @NotNull String key) {
         PermissionRegistry registry = SkylliaAPI.getPermissionRegistry();
+        Locale locale = resolveLocale(player);
+
+        if (key.startsWith("name_")) {
+            return resolveNodeMeta(registry, key.substring("name_".length()), MetaType.NAME, locale);
+        }
+        if (key.startsWith("desc_")) {
+            return resolveNodeMeta(registry, key.substring("desc_".length()), MetaType.DESCRIPTION, locale);
+        }
 
         RoleType role;
         String permKey;
@@ -62,7 +104,40 @@ public class PermissionsHandler implements PlaceholderHandler {
         PermissionId pid = registry.getIfPresent(namespacedKey);
         if (pid == null) return null;
 
-        boolean allowed = island.getCompiledPermissions().has(registry, role, pid);
-        return String.valueOf(allowed);
+        return String.valueOf(island.getCompiledPermissions().has(registry, role, pid));
     }
+
+    /**
+     * Resolves the translated string for a permission metadata field.
+     * <p>
+     * If the Adventure replacer is active in PAPI, returns the raw MiniMessage string
+     * so Adventure can render it natively in the component pipeline.
+     * Otherwise, serializes the rendered {@code Component} to legacy §-codes for
+     * compatibility with plugins that only understand legacy formatting (e.g. DeluxeMenus).
+     */
+    private @Nullable String resolveNodeMeta(@NotNull PermissionRegistry registry,
+                                             @NotNull String rawKey,
+                                             @NotNull MetaType type,
+                                             @NotNull Locale locale) {
+        NamespacedKey namespacedKey = SkylliaPAPIUtils.parseKeyLenient(rawKey);
+        if (namespacedKey == null) return "";
+
+        PermissionId pid = registry.getIfPresent(namespacedKey);
+        if (pid == null) return "";
+
+        PermissionNode node = registry.node(pid);
+        String langKey = switch (type) {
+            case NAME -> node.displayName();
+            case DESCRIPTION -> node.description();
+        };
+
+        if (adventureReplacer) {
+            return ConfigLoader.language.translateRaw(locale, langKey, Map.of());
+        } else {
+            return LegacyComponentSerializer.legacySection()
+                    .serialize(ConfigLoader.language.translate(locale, langKey, Map.of(), false));
+        }
+    }
+
+    private enum MetaType {NAME, DESCRIPTION}
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/PermissionsHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/PermissionsHandler.java
@@ -1,0 +1,68 @@
+package fr.euphyllia.skyllia.papi.handlers;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.permissions.PermissionId;
+import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import org.bukkit.NamespacedKey;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Handles {@code %skyllia_permissions_*%} placeholders.
+ *
+ * <p>Two forms are supported:
+ * <ul>
+ *   <li>{@code permissions_<perm_key>} — checks against the <em>requesting player's</em> role.</li>
+ *   <li>{@code permissions_role_<ROLE>_<perm_key>} — checks against the specified role regardless
+ *       of who is requesting (useful for displaying permission tables in GUIs).</li>
+ * </ul>
+ * <p>
+ * Both return {@code "true"} or {@code "false"}.
+ */
+public class PermissionsHandler implements PlaceholderHandler {
+
+    @Override
+    public @NotNull String prefix() {
+        return "permissions";
+    }
+
+    @Override
+    public @Nullable String handle(@NotNull OfflinePlayer player,
+                                   @NotNull Island island,
+                                   @NotNull String key) {
+        PermissionRegistry registry = SkylliaAPI.getPermissionRegistry();
+
+        RoleType role;
+        String permKey;
+
+        if (key.startsWith("role_")) {
+            // Format: role_<ROLE>_<perm_key>
+            String withoutPrefix = key.substring("role_".length());
+            int separatorIndex = withoutPrefix.indexOf('_');
+            if (separatorIndex <= 0) return null;
+
+            String roleName = withoutPrefix.substring(0, separatorIndex);
+            permKey = withoutPrefix.substring(separatorIndex + 1);
+
+            role = SkylliaPAPIUtils.parseRole(roleName);
+            if (role == null) return null;
+        } else {
+            // Format: <perm_key>  →  use requesting player's role
+            role = SkylliaPAPIUtils.resolveRole(island, player.getUniqueId());
+            permKey = key;
+        }
+
+        NamespacedKey namespacedKey = SkylliaPAPIUtils.parseKeyLenient(permKey);
+        if (namespacedKey == null) return null;
+
+        PermissionId pid = registry.getIfPresent(namespacedKey);
+        if (pid == null) return null;
+
+        boolean allowed = island.getCompiledPermissions().has(registry, role, pid);
+        return String.valueOf(allowed);
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/PlaceholderHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/PlaceholderHandler.java
@@ -1,0 +1,35 @@
+package fr.euphyllia.skyllia.papi.handlers;
+
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Contract for a single-responsibility placeholder handler.
+ * <p>
+ * Each implementation handles one prefix group (e.g. {@code island_},
+ * {@code banned_}) and is registered in {@link fr.euphyllia.skyllia.papi.SkylliaExpansion}.
+ * <p>
+ * The {@code key} passed to {@link #handle} is the portion of the placeholder
+ * that comes <em>after</em> the prefix has been stripped by the router.
+ */
+public interface PlaceholderHandler {
+
+    /**
+     * Returns the prefix this handler is responsible for (without trailing underscore).
+     * <p>
+     * Example: {@code "island"} matches placeholders starting with {@code island_}.
+     */
+    @NotNull String prefix();
+
+    /**
+     * Processes the placeholder and returns the resolved value.
+     *
+     * @param player the requesting player (may be offline)
+     * @param island the island associated with the player (never {@code null})
+     * @param key    the placeholder key with the prefix already stripped
+     * @return the resolved string value, or {@code null} if the key is unrecognized
+     */
+    @Nullable String handle(@NotNull OfflinePlayer player, @NotNull Island island, @NotNull String key);
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/WarpHandler.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/papi/handlers/WarpHandler.java
@@ -1,0 +1,104 @@
+package fr.euphyllia.skyllia.papi.handlers;
+
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
+import fr.euphyllia.skyllia.papi.SkylliaPAPIUtils;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Handles {@code %skyllia_warp_*%} placeholders.
+ * Exposes the island's warp list as indexed entries,
+ * suitable for rendering dynamic GUIs in DeluxeMenus.
+ *
+ * <table>
+ *   <caption>Available placeholders</caption>
+ *   <tr><th>Placeholder</th><th>Returns</th></tr>
+ *   <tr><td>warp_count</td><td>Total number of warps</td></tr>
+ *   <tr><td>warp_has_&lt;N&gt;</td><td>{@code true} if index N exists, otherwise {@code false}</td></tr>
+ *   <tr><td>warp_name_&lt;N&gt;</td><td>Name of the warp at index N</td></tr>
+ *   <tr><td>warp_world_&lt;N&gt;</td><td>World name of the warp at index N</td></tr>
+ *   <tr><td>warp_x_&lt;N&gt;</td><td>X coordinate (block) of the warp at index N</td></tr>
+ *   <tr><td>warp_y_&lt;N&gt;</td><td>Y coordinate (block) of the warp at index N</td></tr>
+ *   <tr><td>warp_z_&lt;N&gt;</td><td>Z coordinate (block) of the warp at index N</td></tr>
+ * </table>
+ *
+ * <p>Indices are zero-based. Out-of-range requests return an empty string.
+ * If {@link Island#getWarps()} returns {@code null}, all placeholders behave
+ * as if the list is empty.
+ */
+public class WarpHandler implements PlaceholderHandler {
+
+    private static @NotNull List<WarpIsland> warps(@NotNull Island island) {
+        List<WarpIsland> warps = island.getWarps();
+        return warps != null ? warps : Collections.emptyList();
+    }
+
+    private static @NotNull String worldName(@NotNull WarpIsland warp) {
+        Location loc = warp.location();
+        if (loc == null || loc.getWorld() == null) return "";
+        return loc.getWorld().getName();
+    }
+
+    @Override
+    public @NotNull String prefix() {
+        return "warp";
+    }
+
+    @Override
+    public @Nullable String handle(@NotNull OfflinePlayer player,
+                                   @NotNull Island island,
+                                   @NotNull String key) {
+        List<WarpIsland> warps = warps(island);
+
+        if (key.equals("count")) {
+            return String.valueOf(warps.size());
+        }
+
+        if (key.startsWith("has_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("has_".length()));
+            if (index < 0) return null;
+            return String.valueOf(index < warps.size());
+        }
+
+        if (key.startsWith("name_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("name_".length()));
+            if (index < 0 || index >= warps.size()) return "";
+            return warps.get(index).warpName();
+        }
+
+        if (key.startsWith("world_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("world_".length()));
+            if (index < 0 || index >= warps.size()) return "";
+            return worldName(warps.get(index));
+        }
+
+        if (key.startsWith("x_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("x_".length()));
+            if (index < 0 || index >= warps.size()) return "";
+            Location loc = warps.get(index).location();
+            return loc != null ? String.valueOf(loc.getBlockX()) : "";
+        }
+
+        if (key.startsWith("y_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("y_".length()));
+            if (index < 0 || index >= warps.size()) return "";
+            Location loc = warps.get(index).location();
+            return loc != null ? String.valueOf(loc.getBlockY()) : "";
+        }
+
+        if (key.startsWith("z_")) {
+            int index = SkylliaPAPIUtils.parseIndex(key.substring("z_".length()));
+            if (index < 0 || index >= warps.size()) return "";
+            Location loc = warps.get(index).location();
+            return loc != null ? String.valueOf(loc.getBlockZ()) : "";
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## New placeholders

### `%skyllia_island_*%`

| Placeholder | Returns |
|---|---|
| `%skyllia_island_id%` | Island UUID |
| `%skyllia_island_owner_name%` | Owner's last known name |
| `%skyllia_island_owner_uuid%` | Owner's UUID |
| `%skyllia_island_create_date%` | Creation date (Timestamp.toString) |
| `%skyllia_island_size%` | Island radius in blocks (double) |
| `%skyllia_island_size_int%` | Island radius rounded to int |
| `%skyllia_island_members_size%` | Current member count |
| `%skyllia_island_members_max_size%` | Maximum member slots |
| `%skyllia_island_role%` / `%skyllia_island_rank%` | Requesting player's role name (e.g. `OWNER`) |
| `%skyllia_island_role_value%` | Numeric value of the requesting player's role |
| `%skyllia_island_access%` | `true` if private, `false` if public |
| `%skyllia_island_disabled%` | `true` if the island is disabled |

---

### `%skyllia_flags_*%` / `%skyllia_gamerule_*%` (legacy alias)

| Placeholder | Returns |
|---|---|
| `%skyllia_flags_<flag_key>%` | `true` / `false` |
| `%skyllia_flags_name_<flag_key>%` | Translated display name of the flag |
| `%skyllia_flags_desc_<flag_key>%` | Translated description of the flag |
| `%skyllia_gamerule_<flag_key>%` | Same as `flags_<flag_key>` (legacy alias) |

The key must be a full namespaced key (`skyllia:island.allow.explosions`). A bare-name fallback is attempted automatically by prepending `skyllia:`, but keys containing dots may not resolve correctly — always prefer the explicit namespace.

Available flag keys:

| Key | Display Name |
|---|---|
| `skyllia:island.allow.explosions` | Explosions |
| `skyllia:island.allow.fire` | Fire |
| `skyllia:island.allow.fluids` | Fluid Flow |
| `skyllia:island.allow.pistons` | Pistons |
| `skyllia:island.allow.mob-grief` | Mob Griefing (All) |
| `skyllia:island.allow.creeper-grief` | Creeper Explosions |
| `skyllia:island.allow.enderman-grief` | Enderman Griefing |
| `skyllia:island.allow.ghast-grief` | Ghast Fireballs |
| `skyllia:island.allow.tnt-grief` | TNT Explosions |
| `skyllia:island.allow.wither-grief` | Wither Destruction |
| `skyllia:island.allow.wither-skull-grief` | Wither Skull Explosions |
| `skyllia:island.spawn.boss.all` | Bosses (All) |
| `skyllia:island.spawn.boss.wither` | Wither |
| `skyllia:island.spawn.boss.ender_dragon` | Ender Dragon |
| `skyllia:island.spawn.hostile_adjacent.all` | Adjacent Hostile Mobs (All) |
| `skyllia:island.spawn.hostile_adjacent.skeleton_horse` | Skeleton Horse |
| `skyllia:island.spawn.hostile.all` | Hostile Mobs (All) |
| `skyllia:island.spawn.hostile.blaze` | Blaze |
| `skyllia:island.spawn.hostile.bogged` | Bogged |
| `skyllia:island.spawn.hostile.breeze` | Breeze |
| `skyllia:island.spawn.hostile.creaking` | Creaking |
| `skyllia:island.spawn.hostile.creeper` | Creeper |
| `skyllia:island.spawn.hostile.elder_guardian` | Elder Guardian |
| `skyllia:island.spawn.hostile.endermite` | Endermite |
| `skyllia:island.spawn.hostile.evoker` | Evoker |
| `skyllia:island.spawn.hostile.ghast` | Ghast |
| `skyllia:island.spawn.hostile.guardian` | Guardian |
| `skyllia:island.spawn.hostile.hoglin` | Hoglin |
| `skyllia:island.spawn.hostile.husk` | Husk |
| `skyllia:island.spawn.hostile.magma_cube` | Magma Cube |
| `skyllia:island.spawn.hostile.parched` | Parched |
| `skyllia:island.spawn.hostile.phantom` | Phantom |
| `skyllia:island.spawn.hostile.piglin_brute` | Piglin Brute |
| `skyllia:island.spawn.hostile.pillager` | Pillager |
| `skyllia:island.spawn.hostile.ravager` | Ravager |
| `skyllia:island.spawn.hostile.shulker` | Shulker |
| `skyllia:island.spawn.hostile.silverfish` | Silverfish |
| `skyllia:island.spawn.hostile.skeleton` | Skeleton |
| `skyllia:island.spawn.hostile.slime` | Slime |
| `skyllia:island.spawn.hostile.stray` | Stray |
| `skyllia:island.spawn.hostile.vex` | Vex |
| `skyllia:island.spawn.hostile.vindicator` | Vindicator |
| `skyllia:island.spawn.hostile.warden` | Warden |
| `skyllia:island.spawn.hostile.witch` | Witch |
| `skyllia:island.spawn.hostile.wither_skeleton` | Wither Skeleton |
| `skyllia:island.spawn.hostile.zoglin` | Zoglin |
| `skyllia:island.spawn.hostile.zombie` | Zombie |
| `skyllia:island.spawn.hostile.zombie_villager` | Zombie Villager |
| `skyllia:island.spawn.neutral.all` | Neutral Mobs (All) |
| `skyllia:island.spawn.neutral.bee` | Bee |
| `skyllia:island.spawn.neutral.cave_spider` | Cave Spider |
| `skyllia:island.spawn.neutral.dolphin` | Dolphin |
| `skyllia:island.spawn.neutral.drowned` | Drowned |
| `skyllia:island.spawn.neutral.enderman` | Enderman |
| `skyllia:island.spawn.neutral.fox` | Fox |
| `skyllia:island.spawn.neutral.goat` | Goat |
| `skyllia:island.spawn.neutral.iron_golem` | Iron Golem |
| `skyllia:island.spawn.neutral.llama` | Llama |
| `skyllia:island.spawn.neutral.panda` | Panda |
| `skyllia:island.spawn.neutral.piglin` | Piglin |
| `skyllia:island.spawn.neutral.polar_bear` | Polar Bear |
| `skyllia:island.spawn.neutral.pufferfish` | Pufferfish |
| `skyllia:island.spawn.neutral.spider` | Spider |
| `skyllia:island.spawn.neutral.trader_llama` | Trader Llama |
| `skyllia:island.spawn.neutral.wolf` | Wolf |
| `skyllia:island.spawn.neutral.zombified_piglin` | Zombified Piglin |
| `skyllia:island.spawn.passive.all` | Passive Mobs (All) |
| `skyllia:island.spawn.passive.allay` | Allay |
| `skyllia:island.spawn.passive.armadillo` | Armadillo |
| `skyllia:island.spawn.passive.axolotl` | Axolotl |
| `skyllia:island.spawn.passive.bat` | Bat |
| `skyllia:island.spawn.passive.camel` | Camel |
| `skyllia:island.spawn.passive.cat` | Cat |
| `skyllia:island.spawn.passive.chicken` | Chicken |
| `skyllia:island.spawn.passive.cod` | Cod |
| `skyllia:island.spawn.passive.cow` | Cow |
| `skyllia:island.spawn.passive.donkey` | Donkey |
| `skyllia:island.spawn.passive.frog` | Frog |
| `skyllia:island.spawn.passive.glow_squid` | Glow Squid |
| `skyllia:island.spawn.passive.horse` | Horse |
| `skyllia:island.spawn.passive.mooshroom` | Mooshroom |
| `skyllia:island.spawn.passive.mule` | Mule |
| `skyllia:island.spawn.passive.ocelot` | Ocelot |
| `skyllia:island.spawn.passive.parrot` | Parrot |
| `skyllia:island.spawn.passive.pig` | Pig |
| `skyllia:island.spawn.passive.rabbit` | Rabbit |
| `skyllia:island.spawn.passive.salmon` | Salmon |
| `skyllia:island.spawn.passive.sheep` | Sheep |
| `skyllia:island.spawn.passive.sniffer` | Sniffer |
| `skyllia:island.spawn.passive.snow_golem` | Snow Golem |
| `skyllia:island.spawn.passive.squid` | Squid |
| `skyllia:island.spawn.passive.strider` | Strider |
| `skyllia:island.spawn.passive.tadpole` | Tadpole |
| `skyllia:island.spawn.passive.tropical_fish` | Tropical Fish |
| `skyllia:island.spawn.passive.turtle` | Turtle |
| `skyllia:island.spawn.passive.villager` | Villager |
| `skyllia:island.spawn.passive.wandering_villager` | Wandering Trader |
| `skyllia:island.spawn.other.all` | Other Entities (All) |
| `skyllia:island.spawn.other.armor_stand` | Armor Stand |
| `skyllia:island.spawn.other.giant` | Giant Zombie |
| `skyllia:island.spawn.other.illusioner` | Illusioner |

---

### `%skyllia_permissions_*%`

| Placeholder | Returns |
|---|---|
| `%skyllia_permissions_<perm_key>%` | `true` / `false` based on the requesting player's role |
| `%skyllia_permissions_role_<ROLE>_<perm_key>%` | `true` / `false` for a specific role |
| `%skyllia_permissions_name_<perm_key>%` | Translated display name of the permission |
| `%skyllia_permissions_desc_<perm_key>%` | Translated description of the permission |

The key must use the full namespaced format (e.g. `skyllia:block.break`).

Available permission keys:

| Key | Display Name |
|---|---|
| `skylliabank:command.bank.deposit` | Bank: Deposit |
| `skylliabank:command.bank.withdraw` | Bank: Withdraw |
| `skylliachest:open_private_island_chest` | Island Chest |
| `skyllia:command.island.access` | Access: Open/Close |
| `skyllia:command.island.ban` | Ban a Player |
| `skyllia:command.island.delwarp` | Delete a Warp |
| `skyllia:command.island.demote` | Demote a Member |
| `skyllia:command.island.expel` | Expel a Player |
| `skyllia:command.island.flag` | Manage Flags |
| `skyllia:command.island.invite` | Invite a Player |
| `skyllia:command.island.kick` | Kick a Member |
| `skyllia:command.island.permission` | Manage Permissions |
| `skyllia:command.island.promote` | Promote a Member |
| `skyllia:command.island.set_biome` | Change Biome |
| `skyllia:command.island.set_home` | Set Home |
| `skyllia:command.island.set_warp` | Create a Warp |
| `skyllia:command.island.manage_trust` | Manage Trust |
| `skyllia:command.island.unban` | Unban a Player |
| `skyllia:command.island.visit.bypass` | Visit (Bypass) |
| `skyllia:block.break` | Break Blocks |
| `skyllia:block.interact` | Interact with Blocks |
| `skyllia:block.physical` | Physical Interactions |
| `skyllia:block.place` | Place Blocks |
| `skyllia:block.use.bucket` | Use Buckets |
| `skyllia:decor.hanging.break` | Remove Decorations |
| `skyllia:decor.hanging.place` | Place Decorations |
| `skyllia:entity.breed` | Breed Animals |
| `skyllia:entity.damage` | Attack Entities |
| `skyllia:entity.interact` | Interact with Entities |
| `skyllia:inventory.modify` | Modify Inventory |
| `skyllia:inventory.open` | Open Containers |
| `skyllia:item.drop` | Drop Items |
| `skyllia:item.pickup` | Pick Up Items |
| `skyllia:player.teleport` | Teleport to Island |

---

### `%skyllia_banned_*%`

| Placeholder | Returns |
|---|---|
| `%skyllia_banned_count%` | Total number of banned players |
| `%skyllia_banned_has_<N>%` | `true` if index N exists |
| `%skyllia_banned_name_<N>%` | Last known name of banned player at index N |
| `%skyllia_banned_uuid_<N>%` | UUID of banned player at index N |

---

### `%skyllia_member_*%`

| Placeholder | Returns |
|---|---|
| `%skyllia_member_has_<N>%` | `true` if index N exists |
| `%skyllia_member_name_<N>%` | Last known name of member at index N |
| `%skyllia_member_uuid_<N>%` | UUID of member at index N |
| `%skyllia_member_role_<N>%` | Role name of member at index N |

---

### `%skyllia_warp_*%`

| Placeholder | Returns |
|---|---|
| `%skyllia_warp_count%` | Total number of warps |
| `%skyllia_warp_has_<N>%` | `true` if index N exists |
| `%skyllia_warp_name_<N>%` | Name of warp at index N |
| `%skyllia_warp_world_<N>%` | World name of warp at index N |
| `%skyllia_warp_x_<N>%` | X coordinate (block) of warp at index N |
| `%skyllia_warp_y_<N>%` | Y coordinate (block) of warp at index N |
| `%skyllia_warp_z_<N>%` | Z coordinate (block) of warp at index N |

---

**Notes:**
- All `<N>` indices are **zero-based**.
- Out-of-range `name`, `uuid`, `role`, `world`, `x/y/z` requests return `""` (never `null`).
- `has_<N>` returns `"false"` cleanly for empty slots in DeluxeMenus.
- Flag and permission keys must use the full namespaced format (e.g. `skyllia:island.allow.fire`, `skyllia:block.break`). The bare-name fallback works for simple keys but may fail for keys containing dots.
- `flags_name_*`, `flags_desc_*`, `permissions_name_*` and `permissions_desc_*` respect the player's locale and PlaceholderAPI's `use_adventure_provided_replacer` setting.