### PR TITLE
feat(island): add per-island build height limits

### DIFF
--- a/api/src/main/java/fr/euphyllia/skyllia/api/database/IslandBuildHeightQuery.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/database/IslandBuildHeightQuery.java
@@ -1,0 +1,52 @@
+package fr.euphyllia.skyllia.api.database;
+
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Abstract query class for managing per-island, per-world build height limits.
+ * <p>
+ * Each island can have a custom {@code min_height} and {@code max_height} per world.
+ * When no custom value is set ({@code null}), the world's default height should be used.
+ * The stored value can never exceed the world's actual min/max height.
+ */
+public abstract class IslandBuildHeightQuery {
+
+    /**
+     * Retrieves the custom minimum build height for the given island in the given world.
+     *
+     * @param island    The island.
+     * @param worldName The name of the world.
+     * @return The custom min height, or {@code null} if none is set (use world default).
+     */
+    public abstract @Nullable Integer getMinHeight(Island island, String worldName);
+
+    /**
+     * Retrieves the custom maximum build height for the given island in the given world.
+     *
+     * @param island    The island.
+     * @param worldName The name of the world.
+     * @return The custom max height, or {@code null} if none is set (use world default).
+     */
+    public abstract @Nullable Integer getMaxHeight(Island island, String worldName);
+
+    /**
+     * Sets the custom minimum build height for the given island in the given world.
+     *
+     * @param island    The island.
+     * @param worldName The name of the world.
+     * @param value     The new min height value.
+     * @return {@code true} if the update succeeded.
+     */
+    public abstract boolean setMinHeight(Island island, String worldName, int value);
+
+    /**
+     * Sets the custom maximum build height for the given island in the given world.
+     *
+     * @param island    The island.
+     * @param worldName The name of the world.
+     * @param value     The new max height value.
+     * @return {@code true} if the update succeeded.
+     */
+    public abstract boolean setMaxHeight(Island island, String worldName, int value);
+}

--- a/api/src/main/java/fr/euphyllia/skyllia/api/skyblock/Island.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/skyblock/Island.java
@@ -3,6 +3,7 @@ package fr.euphyllia.skyllia.api.skyblock;
 import fr.euphyllia.skyllia.api.exceptions.MaxIslandSizeExceedException;
 import fr.euphyllia.skyllia.api.permissions.CompiledPermissions;
 import fr.euphyllia.skyllia.api.permissions.IslandFlags;
+import fr.euphyllia.skyllia.api.skyblock.model.HeightType;
 import fr.euphyllia.skyllia.api.skyblock.model.Position;
 import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
 import org.bukkit.Location;
@@ -222,4 +223,36 @@ public abstract class Island {
      */
     public abstract void setCenterLocation(Location location);
 
+    /**
+     * Returns the custom minimum build height for this island in the given world,
+     * or {@code null} if no custom value is set (the world default applies).
+     *
+     * @param worldName The name of the world.
+     * @return The custom min height, or {@code null}.
+     */
+    public abstract @Nullable Integer getBuildMinHeight(String worldName);
+
+    /**
+     * Returns the custom maximum build height for this island in the given world,
+     * or {@code null} if no custom value is set (the world default applies).
+     *
+     * @param worldName The name of the world.
+     * @return The custom max height, or {@code null}.
+     */
+    public abstract @Nullable Integer getBuildMaxHeight(String worldName);
+
+    /**
+     * Sets a custom build-height limit (min or max) for this island in the given world.
+     * <p>
+     * The value is silently clamped so it never exceeds the world's actual height bounds.
+     * </p>
+     *
+     * @param worldName The name of the world.
+     * @param type      {@link HeightType#MIN} or {@link HeightType#MAX}.
+     * @param value     The desired height value.
+     * @return {@code true} if the database update succeeded.
+     */
+    public abstract boolean setBuildHeight(String worldName, HeightType type, int value);
+
 }
+

--- a/api/src/main/java/fr/euphyllia/skyllia/api/skyblock/model/HeightType.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/skyblock/model/HeightType.java
@@ -1,0 +1,9 @@
+package fr.euphyllia.skyllia.api.skyblock.model;
+
+/**
+ * Represents the type of build-height limit (minimum or maximum).
+ */
+public enum HeightType {
+    MIN,
+    MAX
+}

--- a/api/src/main/java/fr/euphyllia/skyllia/api/skyblock/model/SchematicSetting.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/skyblock/model/SchematicSetting.java
@@ -1,5 +1,7 @@
 package fr.euphyllia.skyllia.api.skyblock.model;
 
+import org.jetbrains.annotations.Nullable;
+
 public record SchematicSetting(double height, String schematicFile, boolean ignoreAirBlocks, boolean copyEntities,
-                               String plugin) {
+                               String plugin, @Nullable Integer minBuildHeight, @Nullable Integer maxBuildHeight) {
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/SkylliaAdminCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/SkylliaAdminCommand.java
@@ -78,6 +78,7 @@ public class SkylliaAdminCommand implements SkylliaCommandInterface {
         registry.registerSubCommand(new ReloadSubCommands(), "reload");
         registry.registerSubCommand(new SetMaxMembersSubCommands(), "set_max_member", "setmaxmembers");
         registry.registerSubCommand(new SetSizeSubCommands(), "set_size", "setsize");
+        registry.registerSubCommand(new SetHeightSubCommands(), "set_height", "setheight");
         registry.registerSubCommand(new SchematicSubCommands(), "schematic", "schem");
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/SetHeightSubCommands.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/SetHeightSubCommands.java
@@ -1,0 +1,226 @@
+package fr.euphyllia.skyllia.commands.admin.subcommands;
+
+import fr.euphyllia.skyllia.Skyllia;
+import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
+import fr.euphyllia.skyllia.api.configuration.WorldConfig;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.model.HeightType;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skyllia.managers.skyblock.SkyblockManager;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Admin sub-command: /isadmin setheight <player> <min|max> <value> confirm
+ * <p>
+ * Sets a per-island, per-world build height limit (min or max) for the island
+ * belonging to the target player.
+ * <p>
+ * The value is silently clamped to the world's actual height bounds:
+ * <ul>
+ *   <li>MIN is clamped to [{@code world.getMinHeight()}, current max]</li>
+ *   <li>MAX is clamped to [current min, {@code world.getMaxHeight()}]</li>
+ * </ul>
+ * If the value already equals or exceeds the world default it is ignored with a warning.
+ */
+public class SetHeightSubCommands implements SubCommandInterface {
+
+    private static final Logger logger = LogManager.getLogger(SetHeightSubCommands.class);
+
+    @Override
+    public void onExecute(@NotNull Plugin plugin, @NotNull CommandSender sender, @NotNull String[] args) {
+        if (!sender.hasPermission("skyllia.admins.commands.island.setheight")) {
+            ConfigLoader.language.sendMessage(sender, "island.player.permission-denied");
+            return;
+        }
+
+        // /isadmin setheight <player> <min|max> <value> confirm
+        if (args.length < 4) {
+            ConfigLoader.language.sendMessage(sender, "island.admin.height.args-missing");
+            return;
+        }
+
+        String playerName = args[0];
+        String typeArg = args[1].toLowerCase();
+        String valueArg = args[2];
+        String confirmArg = args[3];
+
+        if (!confirmArg.equalsIgnoreCase("confirm")) {
+            ConfigLoader.language.sendMessage(sender, "island.admin.height.args-missing");
+            return;
+        }
+
+        HeightType heightType;
+        if (typeArg.equals("min")) {
+            heightType = HeightType.MIN;
+        } else if (typeArg.equals("max")) {
+            heightType = HeightType.MAX;
+        } else {
+            ConfigLoader.language.sendMessage(sender, "island.admin.height.invalid-type");
+            return;
+        }
+
+        int requestedValue;
+        try {
+            requestedValue = Integer.parseInt(valueArg);
+        } catch (NumberFormatException e) {
+            ConfigLoader.language.sendMessage(sender, "island.admin.height.not-an-number");
+            return;
+        }
+
+        try {
+            // Resolve target player UUID
+            UUID playerId;
+            try {
+                playerId = UUID.fromString(playerName);
+            } catch (IllegalArgumentException ignored) {
+                playerId = Bukkit.getPlayerUniqueId(playerName);
+            }
+
+            if (playerId == null) {
+                ConfigLoader.language.sendMessage(sender, "island.player.player-not-found");
+                return;
+            }
+
+            SkyblockManager skyblockManager = Skyllia.getInstance().getInterneAPI().getSkyblockManager();
+            Island island = skyblockManager.getIslandByPlayerId(playerId);
+
+            if (island == null) {
+                ConfigLoader.language.sendMessage(sender, "island.player.no-island");
+                return;
+            }
+
+            // Determine which world to apply the limit to.
+            // If the sender is a player in a skyblock world we use that world,
+            // otherwise we fall back to the first configured skyblock world.
+            World targetWorld = resolveWorld(sender);
+            if (targetWorld == null) {
+                ConfigLoader.language.sendMessage(sender, "island.admin.height.no-world");
+                return;
+            }
+
+            String worldName = targetWorld.getName();
+            int worldMin = targetWorld.getMinHeight();
+            int worldMax = targetWorld.getMaxHeight();
+
+            // Clamp and validate
+            int clampedValue;
+            if (heightType == HeightType.MIN) {
+                if (requestedValue <= worldMin) {
+                    // Value at or below world floor — treat as "reset to default" (use world default)
+                    ConfigLoader.language.sendMessage(sender, "island.admin.height.below-world-min");
+                    return;
+                }
+                if (requestedValue >= worldMax) {
+                    // Would be equal/above ceiling — clamp silently to worldMax - 1
+                    clampedValue = worldMax - 1;
+                    logger.warn("Requested min height {} for island {} exceeds world max {}; clamped to {}",
+                            requestedValue, island.getId(), worldMax, clampedValue);
+                } else {
+                    clampedValue = requestedValue;
+                }
+            } else {
+                if (requestedValue >= worldMax) {
+                    // Value at or above world ceiling — treat as "reset to default"
+                    ConfigLoader.language.sendMessage(sender, "island.admin.height.above-world-max");
+                    return;
+                }
+                if (requestedValue <= worldMin) {
+                    // Would be at/below floor — clamp silently to worldMin + 1
+                    clampedValue = worldMin + 1;
+                    logger.warn("Requested max height {} for island {} is below world min {}; clamped to {}",
+                            requestedValue, island.getId(), worldMin, clampedValue);
+                } else {
+                    clampedValue = requestedValue;
+                }
+            }
+
+            boolean updated = island.setBuildHeight(worldName, heightType, clampedValue);
+            if (updated) {
+                ConfigLoader.language.sendMessage(sender, "island.admin.height.success");
+            } else {
+                ConfigLoader.language.sendMessage(sender, "island.admin.height.failed");
+            }
+
+        } catch (Exception e) {
+            logger.log(Level.FATAL, e.getMessage(), e);
+            ConfigLoader.language.sendMessage(sender, "island.generic.unexpected-error");
+        }
+    }
+
+    /**
+     * Resolves the world to apply the height limit to.
+     * <p>
+     * Uses the sender's current world if they are a player in a skyblock world,
+     * otherwise returns the first skyblock world found in the world configuration.
+     */
+    private World resolveWorld(CommandSender sender) {
+        if (sender instanceof Player player) {
+            World w = player.getWorld();
+            if (ConfigLoader.worldManager.getWorldConfig(w.getName()) != null) {
+                return w;
+            }
+        }
+        for (WorldConfig wc : ConfigLoader.worldManager.getWorldConfigs().values()) {
+            World w = Bukkit.getWorld(wc.getWorldName());
+            if (w != null) return w;
+        }
+        return null;
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NotNull String[] args) {
+        if (!sender.hasPermission("skyllia.admins.commands.island.setheight")) {
+            return Collections.emptyList();
+        }
+
+        // ARG #1 : player name
+        if (args.length == 1) {
+            String partial = args[0].trim().toLowerCase();
+            return Bukkit.getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .filter(name -> name.toLowerCase().startsWith(partial))
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+
+        // ARG #2 : min | max
+        if (args.length == 2) {
+            String partial = args[1].trim().toLowerCase();
+            return Stream.of("min", "max")
+                    .filter(s -> s.startsWith(partial))
+                    .collect(Collectors.toList());
+        }
+
+        // ARG #3 : example height values
+        if (args.length == 3) {
+            String partial = args[2].trim();
+            return Stream.of("-64", "0", "64", "128", "256", "320")
+                    .filter(v -> v.startsWith(partial))
+                    .collect(Collectors.toList());
+        }
+
+        // ARG #4 : confirm
+        if (args.length == 4) {
+            String partial = args[3].trim().toLowerCase();
+            return Stream.of("confirm")
+                    .filter(s -> s.startsWith(partial))
+                    .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
@@ -7,10 +7,7 @@ import fr.euphyllia.skyllia.api.event.SkyblockCreateEvent;
 import fr.euphyllia.skyllia.api.event.SkyblockLoadEvent;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
-import fr.euphyllia.skyllia.api.skyblock.model.IslandSettings;
-import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
-import fr.euphyllia.skyllia.api.skyblock.model.SchematicPlugin;
-import fr.euphyllia.skyllia.api.skyblock.model.SchematicSetting;
+import fr.euphyllia.skyllia.api.skyblock.model.*;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skyllia.cache.commands.CommandCacheExecution;
 import fr.euphyllia.skyllia.cache.island.IslandCreationQueue;
@@ -139,6 +136,12 @@ public class CreateSubCommand implements SubCommandInterface {
                             if (!success) {
                                 island.setDisable(true);
                                 throw new RuntimeException("Schematic paste failed for world " + worldName);
+                            }
+                            if (setting.minBuildHeight() != null) {
+                                island.setBuildHeight(worldName, HeightType.MIN, setting.minBuildHeight());
+                            }
+                            if (setting.maxBuildHeight() != null) {
+                                island.setBuildHeight(worldName, HeightType.MAX, setting.maxBuildHeight());
                             }
                             if (first) {
                                 island.addWarps("home", center, true);

--- a/plugin/src/main/java/fr/euphyllia/skyllia/configuration/manager/SchematicConfigManager.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/configuration/manager/SchematicConfigManager.java
@@ -56,9 +56,12 @@ public class SchematicConfigManager implements IConfigurationProvider {
             boolean copyEntities = getOrSetDefault(node, "copy-entities", true, Boolean.class);
             String pluginName = getOrSetDefault(node, "plugin", "WorldEdit", String.class);
 
+            Integer minBuildHeight = getOrSetDefault(node, "min-build-height", null, Integer.class);
+            Integer maxBuildHeight = getOrSetDefault(node, "max-build-height", null, Integer.class);
+
             schematicMap
                     .computeIfAbsent(islandType, k -> new HashMap<>())
-                    .put(worldName, new SchematicSetting(height, schematicFile, ignoreAirBlocks, copyEntities, pluginName));
+                    .put(worldName, new SchematicSetting(height, schematicFile, ignoreAirBlocks, copyEntities, pluginName, minBuildHeight, maxBuildHeight));
         }
 
         if (schematicMap.isEmpty()) {
@@ -86,6 +89,9 @@ public class SchematicConfigManager implements IConfigurationProvider {
     public <T> T getOrSetDefault(CommentedConfig node, String path, T defaultValue, Class<T> expectedClass) {
         Object value = node.get(path);
         if (value == null) {
+            if (defaultValue == null) {
+                return null;
+            }
             node.set(path, defaultValue);
             changed = true;
             return defaultValue;
@@ -137,7 +143,7 @@ public class SchematicConfigManager implements IConfigurationProvider {
     public SchematicSetting getSchematicSetting(String islandType, String worldName) {
         return schematicMap
                 .getOrDefault(islandType, new HashMap<>())
-                .getOrDefault(worldName, new SchematicSetting(64.0, "./schematics/default.schem", true, true, "Internal"));
+                .getOrDefault(worldName, new SchematicSetting(64.0, "./schematics/default.schem", true, true, "Internal", null, null));
     }
 
     public Map<String, Map<String, SchematicSetting>> getSchematics() {

--- a/plugin/src/main/java/fr/euphyllia/skyllia/database/IslandQuery.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/database/IslandQuery.java
@@ -25,6 +25,7 @@ public class IslandQuery {
     private IslandMemberQuery islandMemberQuery;
     private IslandPermissionQuery islandPermissionQuery;
     private IslandCustomDataQuery islandCustomDataQuery;
+    private IslandBuildHeightQuery islandBuildHeightQuery;
 
     public IslandQuery(InterneAPI api) {
         this.api = api;
@@ -49,6 +50,7 @@ public class IslandQuery {
             this.islandMemberQuery = new MariaDBIslandMember(loader);
             this.islandPermissionQuery = new MariaDBIslandPermission(loader);
             this.islandCustomDataQuery = new MariaDBIslandCustomData(loader);
+            this.islandBuildHeightQuery = new MariaDBIslandBuildHeight(loader);
 
             return;
         }
@@ -62,6 +64,7 @@ public class IslandQuery {
             this.islandMemberQuery = new PostgreSQLIslandMember(loader);
             this.islandPermissionQuery = new PostgreSQLIslandPermission(loader);
             this.islandCustomDataQuery = new PostgreSQLIslandCustomData(loader);
+            this.islandBuildHeightQuery = new PostgreSQLIslandBuildHeight(loader);
 
             return;
         }
@@ -81,6 +84,7 @@ public class IslandQuery {
             this.islandMemberQuery = new SQLiteIslandMember(sqliteLoader);
             this.islandPermissionQuery = new SQLiteIslandPermission(sqliteLoader);
             this.islandCustomDataQuery = new SQLiteIslandCustomData(sqliteLoader);
+            this.islandBuildHeightQuery = new SQLiteIslandBuildHeight(sqliteLoader);
 
             return;
         }
@@ -114,5 +118,9 @@ public class IslandQuery {
 
     public IslandPermissionQuery getIslandPermissionQuery() {
         return this.islandPermissionQuery;
+    }
+
+    public IslandBuildHeightQuery getIslandBuildHeightQuery() {
+        return this.islandBuildHeightQuery;
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/database/mariadb/MariaDBDatabaseInitialize.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/database/mariadb/MariaDBDatabaseInitialize.java
@@ -155,6 +155,18 @@ public class MariaDBDatabaseInitialize extends DatabaseInitializeQuery {
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
             """;
 
+    private static final String CREATE_ISLANDS_BUILD_HEIGHT_TABLE = """
+            CREATE TABLE IF NOT EXISTS islands_build_height (
+                island_id  CHAR(36)     NOT NULL,
+                world_name VARCHAR(255) NOT NULL,
+                min_height INT          NOT NULL,
+                max_height INT          NOT NULL,
+                PRIMARY KEY (island_id, world_name),
+                CONSTRAINT islands_build_height_FK
+                    FOREIGN KEY (island_id) REFERENCES islands (island_id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+            """;
+
 
     public final int regionDistance;
     public final int maxIslands;
@@ -191,6 +203,7 @@ public class MariaDBDatabaseInitialize extends DatabaseInitializeQuery {
         exec(CREATE_MEMBERS_BY_PLAYER_INDEX);
         exec(CREATE_MEMBER_BY_ISLAND_ROLE_INDEX);
         exec(CREATE_ISLAND_CENTER_LOCATIONS_TABLE);
+        exec(CREATE_ISLANDS_BUILD_HEIGHT_TABLE);
     }
 
     private void applyMigrations() {

--- a/plugin/src/main/java/fr/euphyllia/skyllia/database/mariadb/MariaDBIslandBuildHeight.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/database/mariadb/MariaDBIslandBuildHeight.java
@@ -1,0 +1,101 @@
+package fr.euphyllia.skyllia.database.mariadb;
+
+import fr.euphyllia.skyllia.api.database.IslandBuildHeightQuery;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.sgbd.utils.model.DatabaseLoader;
+import fr.euphyllia.skyllia.sgbd.utils.sql.SQLExecute;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class MariaDBIslandBuildHeight extends IslandBuildHeightQuery {
+
+    private static final Logger log = LoggerFactory.getLogger(MariaDBIslandBuildHeight.class);
+
+    private static final String SELECT_MIN = """
+            SELECT min_height
+            FROM islands_build_height
+            WHERE island_id = ? AND world_name = ?;
+            """;
+
+    private static final String SELECT_MAX = """
+            SELECT max_height
+            FROM islands_build_height
+            WHERE island_id = ? AND world_name = ?;
+            """;
+
+    private static final String UPSERT_MIN = """
+            INSERT INTO islands_build_height (island_id, world_name, min_height, max_height)
+            VALUES (?, ?, ?, 0)
+            ON DUPLICATE KEY UPDATE min_height = VALUES(min_height);
+            """;
+
+    private static final String UPSERT_MAX = """
+            INSERT INTO islands_build_height (island_id, world_name, min_height, max_height)
+            VALUES (?, ?, 0, ?)
+            ON DUPLICATE KEY UPDATE max_height = VALUES(max_height);
+            """;
+
+    private final DatabaseLoader databaseLoader;
+
+    public MariaDBIslandBuildHeight(DatabaseLoader databaseLoader) {
+        this.databaseLoader = databaseLoader;
+    }
+
+    @Override
+    public @Nullable Integer getMinHeight(Island island, String worldName) {
+        return SQLExecute.queryMap(
+                databaseLoader,
+                SELECT_MIN,
+                List.of(island.getId().toString(), worldName),
+                rs -> {
+                    try {
+                        return rs.next() ? rs.getInt("min_height") : null;
+                    } catch (SQLException e) {
+                        log.error("SQL error reading min_height for island {} world {}", island.getId(), worldName, e);
+                        return null;
+                    }
+                }
+        );
+    }
+
+    @Override
+    public @Nullable Integer getMaxHeight(Island island, String worldName) {
+        return SQLExecute.queryMap(
+                databaseLoader,
+                SELECT_MAX,
+                List.of(island.getId().toString(), worldName),
+                rs -> {
+                    try {
+                        return rs.next() ? rs.getInt("max_height") : null;
+                    } catch (SQLException e) {
+                        log.error("SQL error reading max_height for island {} world {}", island.getId(), worldName, e);
+                        return null;
+                    }
+                }
+        );
+    }
+
+    @Override
+    public boolean setMinHeight(Island island, String worldName, int value) {
+        int affected = SQLExecute.update(
+                databaseLoader,
+                UPSERT_MIN,
+                List.of(island.getId().toString(), worldName, value)
+        );
+        return affected > 0;
+    }
+
+    @Override
+    public boolean setMaxHeight(Island island, String worldName, int value) {
+        int affected = SQLExecute.update(
+                databaseLoader,
+                UPSERT_MAX,
+                List.of(island.getId().toString(), worldName, value)
+        );
+        return affected > 0;
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/database/postgresql/PostgreSQLDatabaseInitialize.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/database/postgresql/PostgreSQLDatabaseInitialize.java
@@ -156,6 +156,18 @@ public class PostgreSQLDatabaseInitialize extends DatabaseInitializeQuery {
             );
             """;
 
+    private static final String CREATE_ISLANDS_BUILD_HEIGHT_TABLE = """
+            CREATE TABLE IF NOT EXISTS %s.islands_build_height (
+                island_id  CHAR(36)     NOT NULL,
+                world_name VARCHAR(255) NOT NULL,
+                min_height INT          NOT NULL,
+                max_height INT          NOT NULL,
+                PRIMARY KEY (island_id, world_name),
+                CONSTRAINT islands_build_height_FK
+                    FOREIGN KEY (island_id) REFERENCES %s.islands (island_id) ON DELETE CASCADE
+            );
+            """;
+
     private final String schema;
     private final DatabaseLoader databaseLoader;
     private final int regionDistance;
@@ -219,6 +231,7 @@ public class PostgreSQLDatabaseInitialize extends DatabaseInitializeQuery {
         exec(CREATE_MEMBERS_BY_PLAYER_INDEX.formatted(s));
         exec(CREATE_MEMBER_BY_ISLAND_ROLE_INDEX.formatted(s));
         exec(CREATE_ISLAND_CENTER_LOCATIONS_TABLE.formatted(s, s));
+        exec(CREATE_ISLANDS_BUILD_HEIGHT_TABLE.formatted(s, s));
     }
 
     private void applyMigrations() {

--- a/plugin/src/main/java/fr/euphyllia/skyllia/database/postgresql/PostgreSQLIslandBuildHeight.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/database/postgresql/PostgreSQLIslandBuildHeight.java
@@ -1,0 +1,101 @@
+package fr.euphyllia.skyllia.database.postgresql;
+
+import fr.euphyllia.skyllia.api.database.IslandBuildHeightQuery;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.sgbd.utils.model.DatabaseLoader;
+import fr.euphyllia.skyllia.sgbd.utils.sql.SQLExecute;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class PostgreSQLIslandBuildHeight extends IslandBuildHeightQuery {
+
+    private static final Logger log = LoggerFactory.getLogger(PostgreSQLIslandBuildHeight.class);
+
+    private static final String SELECT_MIN = """
+            SELECT min_height
+            FROM islands_build_height
+            WHERE island_id = ? AND world_name = ?;
+            """;
+
+    private static final String SELECT_MAX = """
+            SELECT max_height
+            FROM islands_build_height
+            WHERE island_id = ? AND world_name = ?;
+            """;
+
+    private static final String UPSERT_MIN = """
+            INSERT INTO islands_build_height (island_id, world_name, min_height, max_height)
+            VALUES (?, ?, ?, 0)
+            ON CONFLICT (island_id, world_name) DO UPDATE SET min_height = EXCLUDED.min_height;
+            """;
+
+    private static final String UPSERT_MAX = """
+            INSERT INTO islands_build_height (island_id, world_name, min_height, max_height)
+            VALUES (?, ?, 0, ?)
+            ON CONFLICT (island_id, world_name) DO UPDATE SET max_height = EXCLUDED.max_height;
+            """;
+
+    private final DatabaseLoader databaseLoader;
+
+    public PostgreSQLIslandBuildHeight(DatabaseLoader databaseLoader) {
+        this.databaseLoader = databaseLoader;
+    }
+
+    @Override
+    public @Nullable Integer getMinHeight(Island island, String worldName) {
+        return SQLExecute.queryMap(
+                databaseLoader,
+                SELECT_MIN,
+                List.of(island.getId().toString(), worldName),
+                rs -> {
+                    try {
+                        return rs.next() ? rs.getInt("min_height") : null;
+                    } catch (SQLException e) {
+                        log.error("SQL error reading min_height for island {} world {}", island.getId(), worldName, e);
+                        return null;
+                    }
+                }
+        );
+    }
+
+    @Override
+    public @Nullable Integer getMaxHeight(Island island, String worldName) {
+        return SQLExecute.queryMap(
+                databaseLoader,
+                SELECT_MAX,
+                List.of(island.getId().toString(), worldName),
+                rs -> {
+                    try {
+                        return rs.next() ? rs.getInt("max_height") : null;
+                    } catch (SQLException e) {
+                        log.error("SQL error reading max_height for island {} world {}", island.getId(), worldName, e);
+                        return null;
+                    }
+                }
+        );
+    }
+
+    @Override
+    public boolean setMinHeight(Island island, String worldName, int value) {
+        int affected = SQLExecute.update(
+                databaseLoader,
+                UPSERT_MIN,
+                List.of(island.getId().toString(), worldName, value)
+        );
+        return affected > 0;
+    }
+
+    @Override
+    public boolean setMaxHeight(Island island, String worldName, int value) {
+        int affected = SQLExecute.update(
+                databaseLoader,
+                UPSERT_MAX,
+                List.of(island.getId().toString(), worldName, value)
+        );
+        return affected > 0;
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/database/sqlite/SQLiteDatabaseInitialize.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/database/sqlite/SQLiteDatabaseInitialize.java
@@ -140,6 +140,17 @@ public class SQLiteDatabaseInitialize extends DatabaseInitializeQuery {
             );
             """;
 
+    private static final String CREATE_ISLANDS_BUILD_HEIGHT_TABLE = """
+            CREATE TABLE IF NOT EXISTS islands_build_height (
+                island_id  TEXT    NOT NULL,
+                world_name TEXT    NOT NULL,
+                min_height INTEGER NOT NULL,
+                max_height INTEGER NOT NULL,
+                PRIMARY KEY (island_id, world_name),
+                FOREIGN KEY (island_id) REFERENCES islands (island_id) ON DELETE CASCADE
+            );
+            """;
+
     private final DatabaseLoader databaseLoader;
 
     public SQLiteDatabaseInitialize(DatabaseLoader databaseLoader) {
@@ -165,6 +176,7 @@ public class SQLiteDatabaseInitialize extends DatabaseInitializeQuery {
         exec(CREATE_ISLANDS_GAMERULE_TABLE);
         exec(CREATE_PERMISSION_REGISTRY_TABLE);
         exec(CREATE_ISLAND_CENTER_LOCATIONS_TABLE);
+        exec(CREATE_ISLANDS_BUILD_HEIGHT_TABLE);
 
         exec(CREATE_ISLANDS_INDEX);
         exec(CREATE_SPIRAL_INDEX);

--- a/plugin/src/main/java/fr/euphyllia/skyllia/database/sqlite/SQLiteIslandBuildHeight.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/database/sqlite/SQLiteIslandBuildHeight.java
@@ -1,0 +1,102 @@
+package fr.euphyllia.skyllia.database.sqlite;
+
+import fr.euphyllia.skyllia.api.database.IslandBuildHeightQuery;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.sgbd.sqlite.SQLiteDatabaseLoader;
+import fr.euphyllia.skyllia.sgbd.utils.sql.SQLExecute;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class SQLiteIslandBuildHeight extends IslandBuildHeightQuery {
+
+    private static final Logger log = LoggerFactory.getLogger(SQLiteIslandBuildHeight.class);
+
+    private static final String SELECT_MIN = """
+            SELECT min_height
+            FROM islands_build_height
+            WHERE island_id = ? AND world_name = ?;
+            """;
+
+    private static final String SELECT_MAX = """
+            SELECT max_height
+            FROM islands_build_height
+            WHERE island_id = ? AND world_name = ?;
+            """;
+
+
+    private static final String UPSERT_MIN = """
+            INSERT INTO islands_build_height (island_id, world_name, min_height, max_height)
+            VALUES (?, ?, ?, 0)
+            ON CONFLICT(island_id, world_name) DO UPDATE SET min_height = excluded.min_height;
+            """;
+
+    private static final String UPSERT_MAX = """
+            INSERT INTO islands_build_height (island_id, world_name, min_height, max_height)
+            VALUES (?, ?, 0, ?)
+            ON CONFLICT(island_id, world_name) DO UPDATE SET max_height = excluded.max_height;
+            """;
+
+    private final SQLiteDatabaseLoader databaseLoader;
+
+    public SQLiteIslandBuildHeight(SQLiteDatabaseLoader databaseLoader) {
+        this.databaseLoader = databaseLoader;
+    }
+
+    @Override
+    public @Nullable Integer getMinHeight(Island island, String worldName) {
+        return SQLExecute.queryMap(
+                databaseLoader,
+                SELECT_MIN,
+                List.of(island.getId().toString(), worldName),
+                rs -> {
+                    try {
+                        return rs.next() ? rs.getInt("min_height") : null;
+                    } catch (SQLException e) {
+                        log.error("SQL error reading min_height for island {} world {}", island.getId(), worldName, e);
+                        return null;
+                    }
+                }
+        );
+    }
+
+    @Override
+    public @Nullable Integer getMaxHeight(Island island, String worldName) {
+        return SQLExecute.queryMap(
+                databaseLoader,
+                SELECT_MAX,
+                List.of(island.getId().toString(), worldName),
+                rs -> {
+                    try {
+                        return rs.next() ? rs.getInt("max_height") : null;
+                    } catch (SQLException e) {
+                        log.error("SQL error reading max_height for island {} world {}", island.getId(), worldName, e);
+                        return null;
+                    }
+                }
+        );
+    }
+
+    @Override
+    public boolean setMinHeight(Island island, String worldName, int value) {
+        int affected = SQLExecute.update(
+                databaseLoader,
+                UPSERT_MIN,
+                List.of(island.getId().toString(), worldName, value)
+        );
+        return affected > 0;
+    }
+
+    @Override
+    public boolean setMaxHeight(Island island, String worldName, int value) {
+        int affected = SQLExecute.update(
+                databaseLoader,
+                UPSERT_MAX,
+                List.of(island.getId().toString(), worldName, value)
+        );
+        return affected > 0;
+    }
+}

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/ListenersUtils.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/ListenersUtils.java
@@ -56,19 +56,73 @@ public class ListenersUtils {
     }
 
     /**
-     * Checks whether a block is outside the island's boundaries. If it is outside, the event is cancelled.
+     * Checks whether a block is outside the island's boundaries (X/Z square AND
+     * per-island build-height limits on the Y axis). If it is outside, the event
+     * is cancelled.
+     *
+     * <p>Y limits are resolved in priority order:
+     * <ol>
+     *   <li>Island-specific custom value stored in {@code islands_build_height}</li>
+     *   <li>World-config value ({@code min-y} / {@code height} from the TOML config)</li>
+     *   <li>Bukkit's own {@link org.bukkit.World#getMinHeight()} /
+     *       {@link org.bukkit.World#getMaxHeight()}</li>
+     * </ol>
+     * When no custom Y restriction has been set the Y check is skipped entirely,
+     * preserving the original behaviour.
      *
      * @param island      The {@link Island} in question.
      * @param location    The {@link Location} to check.
      * @param cancellable The event that can be cancelled.
      * @return {@code true} if the block is outside the island boundaries, {@code false} otherwise.
      */
-    public static boolean isBlockOutsideIsland(Island island, Location location, Cancellable cancellable) {
+    public static boolean isBlockOutsideIsland(Island island, Location location, @Nullable Cancellable cancellable) {
         Position origin = island.getPosition();
         Location center = RegionHelper.getCenterRegion(location.getWorld(), origin.x(), origin.z());
-        boolean outside = !RegionHelper.isBlockWithinSquare(center, location.getBlockX(), location.getBlockZ(), island.getSize());
-        if (outside) cancellable.setCancelled(true);
-        return outside;
+
+        boolean outsideXZ = !RegionHelper.isBlockWithinSquare(center, location.getBlockX(), location.getBlockZ(), island.getSize());
+        if (outsideXZ) {
+            if (cancellable != null) {
+                cancellable.setCancelled(true);
+            }
+            return true;
+        }
+
+        if (location.getWorld() != null) {
+            World world = location.getWorld();
+            String worldName = world.getName();
+
+            Integer customMin = island.getBuildMinHeight(worldName);
+            Integer customMax = island.getBuildMaxHeight(worldName);
+
+            // Only enforce when at least one custom limit exists
+            if (customMin != null || customMax != null) {
+                int effectiveMin = resolveMin(world, customMin);
+                int effectiveMax = resolveMax(world, customMax);
+
+                if (location.getBlockY() < effectiveMin || location.getBlockY() > effectiveMax) {
+                    if (cancellable != null) {
+                        cancellable.setCancelled(true);
+                    }
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static int resolveMin(World world, @Nullable Integer customMin) {
+        if (customMin != null) return customMin;
+        WorldConfig wc = WorldUtils.getWorldConfig(world.getName());
+        if (wc != null && wc.getWorldMinY() != null) return wc.getWorldMinY();
+        return world.getMinHeight();
+    }
+
+    private static int resolveMax(World world, @Nullable Integer customMax) {
+        if (customMax != null) return customMax;
+        WorldConfig wc = WorldUtils.getWorldConfig(world.getName());
+        if (wc != null && wc.getWorldHeight() != null) return wc.getWorldHeight();
+        return world.getMaxHeight();
     }
 
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockBreakPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockBreakPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -29,9 +30,14 @@ public class BlockBreakPermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_BREAK, "skyllia.player.break.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.break.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_BREAK);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockInteractPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockInteractPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -36,9 +37,14 @@ public class BlockInteractPermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_INTERACT, "skyllia.player.interact.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.interact.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_INTERACT);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockPhysicalPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockPhysicalPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -36,9 +37,14 @@ public class BlockPhysicalPermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_PHYSICAL, "skyllia.player.physical.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.physical.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_PHYSICAL);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockPlacePermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/block/BlockPlacePermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -29,9 +30,14 @@ public class BlockPlacePermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_PLACE, "skyllia.player.place.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.place.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, BLOCK_PLACE);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/decor/DecorHangingBreakPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/decor/DecorHangingBreakPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -31,9 +32,14 @@ public class DecorHangingBreakPermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, DECOR_HANGING_BREAK, "skyllia.player.decor.hanging.break.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.decor.hanging.break.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, DECOR_HANGING_BREAK);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/decor/DecorHangingPlacePermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/decor/DecorHangingPlacePermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -30,9 +31,14 @@ public class DecorHangingPlacePermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, DECOR_HANGING_PLACE, "skyllia.player.decor.hanging.place.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.decor.hanging.place.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, DECOR_HANGING_PLACE);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/entity/EntityInteractPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/entity/EntityInteractPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -31,9 +32,14 @@ public class EntityInteractPermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, ENTITY_INTERACT, "skyllia.player.entity.interact.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.entity.interact.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, ENTITY_INTERACT);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnBossFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnBossFlag.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
@@ -49,6 +50,10 @@ public class IslandMobSpawnBossFlag implements FlagModule {
         Island island = SkylliaAPI.getIslandByChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
         if (island == null) return;
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, specific, ALLOW_SPAWN_ALL_BOSS)) {
+            cancel.run();
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, null)) {
             cancel.run();
         }
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnHostileAdjacentFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnHostileAdjacentFlag.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
@@ -50,6 +51,10 @@ public class IslandMobSpawnHostileAdjacentFlag implements FlagModule {
         Island island = SkylliaAPI.getIslandByChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
         if (island == null) return;
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, specific, ALLOW_SPAWN_ALL_HOSTILE_ADJACENT)) {
+            cancel.run();
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, null)) {
             cancel.run();
         }
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnHostileFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnHostileFlag.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
@@ -50,6 +51,10 @@ public class IslandMobSpawnHostileFlag implements FlagModule {
         Island island = SkylliaAPI.getIslandByChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
         if (island == null) return;
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, specific, ALLOW_SPAWN_ALL_HOSTILE)) {
+            cancel.run();
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, null)) {
             cancel.run();
         }
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnNeutralFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnNeutralFlag.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
@@ -50,6 +51,10 @@ public class IslandMobSpawnNeutralFlag implements FlagModule {
         Island island = SkylliaAPI.getIslandByChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
         if (island == null) return;
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, specific, ALLOW_SPAWN_ALL_NEUTRAL)) {
+            cancel.run();
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, null)) {
             cancel.run();
         }
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnOtherFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnOtherFlag.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
@@ -50,6 +51,10 @@ public class IslandMobSpawnOtherFlag implements FlagModule {
         Island island = SkylliaAPI.getIslandByChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
         if (island == null) return;
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, specific, ALLOW_SPAWN_ALL_OTHER)) {
+            cancel.run();
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, null)) {
             cancel.run();
         }
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnPassiveFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/entity/IslandMobSpawnPassiveFlag.java
@@ -7,6 +7,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
@@ -50,6 +51,10 @@ public class IslandMobSpawnPassiveFlag implements FlagModule {
         Island island = SkylliaAPI.getIslandByChunk(location.getBlockX() >> 4, location.getBlockZ() >> 4);
         if (island == null) return;
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, specific, ALLOW_SPAWN_ALL_PASSIVE)) {
+            cancel.run();
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, null)) {
             cancel.run();
         }
     }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/explosion/IslandAllowExplosionsBlockPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/explosion/IslandAllowExplosionsBlockPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -28,6 +29,11 @@ public class IslandAllowExplosionsBlockPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_EXPLOSIONS)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/explosion/IslandAllowExplosionsEntityPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/explosion/IslandAllowExplosionsEntityPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -29,6 +30,11 @@ public class IslandAllowExplosionsEntityPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_EXPLOSIONS)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/fire/IslandAllowFireBurnPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/fire/IslandAllowFireBurnPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -28,6 +29,11 @@ public class IslandAllowFireBurnPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_FIRE)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/fire/IslandAllowFireIgnitePermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/fire/IslandAllowFireIgnitePermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -30,6 +31,11 @@ public class IslandAllowFireIgnitePermissions implements FlagModule {
                 .hasFlag(island, ISLAND_ALLOW_FIRE);
         if (!flagEnabled) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/fire/IslandAllowFireSpreadPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/fire/IslandAllowFireSpreadPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -28,6 +29,11 @@ public class IslandAllowFireSpreadPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_FIRE)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandAllowEndermanGriefPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandAllowEndermanGriefPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Enderman;
@@ -32,6 +33,10 @@ public class IslandAllowEndermanGriefPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_ENDERMAN_GRIEF, ISLAND_ALLOW_MOB_GRIEF)) {
             event.setCancelled(true);
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandCreeperGriefFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandCreeperGriefFlag.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Creeper;
@@ -47,6 +48,10 @@ public class IslandCreeperGriefFlag implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ALLOW_CREEPER_GRIEF, ALLOW_MOB_GRIEF)) {
             event.setCancelled(true);
+            return;
+        }
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandEndermanGriefFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandEndermanGriefFlag.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Enderman;
@@ -46,6 +47,11 @@ public class IslandEndermanGriefFlag implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ALLOW_ENDERMAN_GRIEF, ALLOW_MOB_GRIEF)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandGhastGriefFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandGhastGriefFlag.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -54,6 +55,11 @@ public class IslandGhastGriefFlag implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ALLOW_GHAST_GRIEF, ALLOW_MOB_GRIEF)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandTntGriefFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandTntGriefFlag.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -50,6 +51,11 @@ public class IslandTntGriefFlag implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ALLOW_TNT_GRIEF, ALLOW_MOB_GRIEF)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandWitherGriefFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandWitherGriefFlag.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Wither;
@@ -47,6 +48,11 @@ public class IslandWitherGriefFlag implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ALLOW_WITHER_GRIEF, ALLOW_MOB_GRIEF)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandWitherSkullGriefFlag.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/grief/IslandWitherSkullGriefFlag.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -49,6 +50,11 @@ public class IslandWitherSkullGriefFlag implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ALLOW_WITHER_SKULL_GRIEF, ALLOW_MOB_GRIEF)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/other/IslandAllowFluidsPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/other/IslandAllowFluidsPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -28,6 +29,11 @@ public class IslandAllowFluidsPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_FLUIDS)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, to, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/redstone/IslandAllowPistonsExtendPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/redstone/IslandAllowPistonsExtendPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -28,6 +29,11 @@ public class IslandAllowPistonsExtendPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_PISTONS)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/redstone/IslandAllowPistonsRetractPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/flags/redstone/IslandAllowPistonsRetractPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.FlagNode;
 import fr.euphyllia.skyllia.api.permissions.IslandFlagRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.FlagModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
@@ -28,6 +29,11 @@ public class IslandAllowPistonsRetractPermissions implements FlagModule {
 
         if (!SkylliaAPI.getPermissionsManager().hasFlag(island, ISLAND_ALLOW_PISTONS)) {
             event.setCancelled(true);
+            return;
+        }
+
+        if (ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/player/ItemDropPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/player/ItemDropPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
@@ -30,9 +31,14 @@ public class ItemDropPermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, ITEM_DROP, "skyllia.player.item.drop.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.item.drop.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, ITEM_DROP);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/player/ItemPickupPermissions.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/permissions/player/ItemPickupPermissions.java
@@ -6,6 +6,7 @@ import fr.euphyllia.skyllia.api.permissions.PermissionNode;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.permissions.modules.PermissionModule;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -31,9 +32,14 @@ public class ItemPickupPermissions implements PermissionModule {
         final Island island = SkylliaAPI.getIslandByChunk(chunkX, chunkZ);
         if (island == null) return;
 
-        final boolean hasPermission = SkylliaAPI.getPermissionsManager().hasPermission(player, island, ITEM_PICKUP, "skyllia.player.item.pickup.bypass");
+        final boolean hasBypass = player.hasPermission("skyllia.player.item.pickup.bypass");
+        final boolean hasPermission = hasBypass || SkylliaAPI.getPermissionsManager().hasPermission(player, island, ITEM_PICKUP);
         if (!hasPermission) {
             event.setCancelled(true);
+            return;
+        }
+        if (!hasBypass && ListenersUtils.isBlockOutsideIsland(island, location, event)) {
+            return;
         }
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/managers/skyblock/IslandHook.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/managers/skyblock/IslandHook.java
@@ -11,6 +11,7 @@ import fr.euphyllia.skyllia.api.permissions.IslandFlags;
 import fr.euphyllia.skyllia.api.permissions.PermissionRegistry;
 import fr.euphyllia.skyllia.api.skyblock.Island;
 import fr.euphyllia.skyllia.api.skyblock.Players;
+import fr.euphyllia.skyllia.api.skyblock.model.HeightType;
 import fr.euphyllia.skyllia.api.skyblock.model.Position;
 import fr.euphyllia.skyllia.api.skyblock.model.WarpIsland;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
@@ -30,12 +31,21 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class IslandHook extends Island {
 
+    /**
+     * Sentinel value stored in the height cache to mean "no custom limit set".
+     * Using Integer cache means null can't be stored in ConcurrentHashMap,
+     * so we use this constant instead.
+     */
+    private static final int HEIGHT_NOT_SET = Integer.MIN_VALUE;
+
     private final Skyllia plugin;
     private final UUID islandId;
     private final Timestamp createDate;
     private final Position position;
     private final int maxMemberInIsland;
     private final Map<World, Location> islandCenterLocations;
+    private final ConcurrentHashMap<String, Integer> buildMinHeightCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Integer> buildMaxHeightCache = new ConcurrentHashMap<>();
     private double islandSize;
     private transient volatile CompiledPermissions compiledPermissions;
     private transient volatile IslandFlags islandFlags;
@@ -102,7 +112,6 @@ public class IslandHook extends Island {
     public boolean setSize(double newSize) {
         double oldSize = this.islandSize;
         this.islandSize = newSize;
-        // Update in database
         boolean isUpdated = this.plugin.getInterneAPI()
                 .getSkyblockManager()
                 .setSizeIsland(this, newSize);
@@ -294,6 +303,7 @@ public class IslandHook extends Island {
         }
     }
 
+    @Override
     public final void invalidateCompiledPermissions() {
         this.compiledPermissions = null;
     }
@@ -355,5 +365,52 @@ public class IslandHook extends Island {
     public void setCenterLocation(Location location) {
         this.islandCenterLocations.put(location.getWorld(), location);
         this.plugin.getInterneAPI().getSkyblockManager().updateCenterLocation(this, location);
+    }
+
+    @Override
+    public @Nullable Integer getBuildMinHeight(String worldName) {
+        Integer cached = buildMinHeightCache.get(worldName);
+        if (cached != null) {
+            return cached == HEIGHT_NOT_SET ? null : cached;
+        }
+        Integer db = this.plugin.getInterneAPI()
+                .getIslandQuery()
+                .getIslandBuildHeightQuery()
+                .getMinHeight(this, worldName);
+        buildMinHeightCache.put(worldName, db != null ? db : HEIGHT_NOT_SET);
+        return db;
+    }
+
+    @Override
+    public @Nullable Integer getBuildMaxHeight(String worldName) {
+        Integer cached = buildMaxHeightCache.get(worldName);
+        if (cached != null) {
+            return cached == HEIGHT_NOT_SET ? null : cached;
+        }
+        Integer db = this.plugin.getInterneAPI()
+                .getIslandQuery()
+                .getIslandBuildHeightQuery()
+                .getMaxHeight(this, worldName);
+        buildMaxHeightCache.put(worldName, db != null ? db : HEIGHT_NOT_SET);
+        return db;
+    }
+
+    @Override
+    public boolean setBuildHeight(String worldName, HeightType type, int value) {
+        boolean ok;
+        if (type == HeightType.MIN) {
+            ok = this.plugin.getInterneAPI()
+                    .getIslandQuery()
+                    .getIslandBuildHeightQuery()
+                    .setMinHeight(this, worldName, value);
+            if (ok) buildMinHeightCache.put(worldName, value);
+        } else {
+            ok = this.plugin.getInterneAPI()
+                    .getIslandQuery()
+                    .getIslandBuildHeightQuery()
+                    .setMaxHeight(this, worldName, value);
+            if (ok) buildMaxHeightCache.put(worldName, value);
+        }
+        return ok;
     }
 }

--- a/plugin/src/main/resources/config/schematics.toml
+++ b/plugin/src/main/resources/config/schematics.toml
@@ -17,6 +17,12 @@ ignore-air-blocks = true
 copy-entities = true
 # Specify the schematic handling plugin: WorldEdit or Internal (WorldEdit and FastAsyncWorldEdit are the same)
 plugin = "WorldEdit"
+# (Optional) Restrict the Y range in which players can build on this island type.
+# If not set, the world's default min/max height applies.
+# min-build-height must be above the world floor (e.g. -64 for overworld), max-build-height below the world ceiling (e.g. 320).
+# Example: players can only build between Y=0 and Y=150 on this island type.
+#min-build-height = 0
+#max-build-height = 150
 
 ["my_first_island.sky-nether"]
 schematic = "./schematics/default.schem"

--- a/plugin/src/main/resources/language/en_GB.toml
+++ b/plugin/src/main/resources/language/en_GB.toml
@@ -254,6 +254,16 @@ no-permission = "You do not have permission to manage this island."
 no-owner = "This island has no owner."
 info = "You are currently on the island of %owner_name% (Island ID: %island_id%, Owner ID: %owner_uuid%)."
 
+[island.admin.height]
+args-missing = "Incomplete command: /skylliadmin setheight <player> <min|max> <value> confirm"
+invalid-type = "Invalid type. Use 'min' or 'max'."
+not-an-number = "The value must be a whole number."
+no-world = "No Skyblock world found."
+below-world-min = "The minimum value is already at the world floor. Please use a higher value."
+above-world-max = "The maximum value is already at the world ceiling. Please use a lower value."
+success = "The island build height has been successfully updated."
+failed = "The build height could not be updated. Please check the console for further details."
+
 [misc]
 unknown-command = "This subcommand does not exist."
 

--- a/plugin/src/main/resources/language/en_US.toml
+++ b/plugin/src/main/resources/language/en_US.toml
@@ -254,6 +254,16 @@ no-permission = "You do not have permission to manage this island."
 no-owner = "This island has no owner."
 info = "You are currently on the island of %owner_name% (Island ID: %island_id%, Owner ID: %owner_uuid%)."
 
+[island.admin.height]
+args-missing = "Incomplete command: /skylliadmin setheight <player> <min|max> <value> confirm"
+invalid-type = "Invalid type. Use 'min' or 'max'."
+not-an-number = "The value must be an integer."
+no-world = "No Skyblock world found."
+below-world-min = "The min value is already at the world floor. Use a higher value."
+above-world-max = "The max value is already at the world ceiling. Use a lower value."
+success = "The island build height has been successfully updated."
+failed = "The build height could not be updated. Please check the console for more details."
+
 [misc]
 unknown-command = "This subcommand does not exist."
 

--- a/plugin/src/main/resources/language/fr_FR.toml
+++ b/plugin/src/main/resources/language/fr_FR.toml
@@ -254,6 +254,16 @@ no-confirm = "Ajoutez 'confirm' à la fin de la commande."
 [island.admin.rank]
 promote-success = "Le joueur %s a été promu."
 
+[island.admin.height]
+args-missing = "Commande incomplète : /skylliadmin setheight <joueur> <nombre> confirm"
+invalid-type = "Type invalide. Utilise 'min' ou 'max'."
+not-an-number = "La valeur doit être un entier."
+no-world = "Aucun monde Skyblock trouvé."
+below-world-min = "La valeur min est déjà au plancher du monde. Utilise une valeur plus haute."
+above-world-max = "La valeur max est déjà au plafond du monde. Utilise une valeur plus basse."
+success = "La hauteur de l'île a été modifiée avec succès."
+failed = "Le changement de hauteur n'a pas pu être effectué. Veuillez vérifier la console pour plus de détails."
+
 [misc]
 unknown-command = "<red>Commande inconnue."
 


### PR DESCRIPTION
- Add islands_build_height table (MariaDB, PostgreSQL, SQLite)
- Add IslandBuildHeightQuery abstract class and 3 implementations
- Add HeightType enum (MIN/MAX)
- Extend Island API with getBuildMinHeight, getBuildMaxHeight, setBuildHeight
- Cache height values in IslandHook to avoid per-event DB queries
- Enforce height limits in ListenersUtils.isBlockOutsideIsland (Y-axis check)
- Add /isadmin setheight <player> <min|max> <value> confirm command
- Support optional min-build-height/max-build-height in schematics.toml
- Apply schematic height config on island creation