### PR TITLE
feat: Add SkylliaIslandLevel addon

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -16,6 +16,7 @@
             <option value="$PROJECT_DIR$/addons/SkylliaChat" />
             <option value="$PROJECT_DIR$/addons/SkylliaChest" />
             <option value="$PROJECT_DIR$/addons/SkylliaInsights" />
+            <option value="$PROJECT_DIR$/addons/SkylliaIslandValue" />
             <option value="$PROJECT_DIR$/addons/SkylliaOre" />
             <option value="$PROJECT_DIR$/api" />
             <option value="$PROJECT_DIR$/database" />

--- a/addons/SkylliaIslandValue/build.gradle.kts
+++ b/addons/SkylliaIslandValue/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
     compileOnly("me.clip:placeholderapi:2.11.6")
 
     compileOnly(project(":api"))
@@ -17,6 +17,7 @@ dependencies {
     compileOnly(project(":database"))
 
     compileOnly("com.electronwill.night-config:toml:3.6.7")
+    compileOnly("com.ezylang:EvalEx:3.6.1")
 }
 
 java {

--- a/addons/SkylliaIslandValue/build.gradle.kts
+++ b/addons/SkylliaIslandValue/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id("java")
+}
+
+group = "fr.euphyllia.skylliaislandlevel"
+
+repositories {
+    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    compileOnly("me.clip:placeholderapi:2.11.6")
+
+    compileOnly(project(":api"))
+    compileOnly(project(":plugin"))
+    compileOnly(project(":database"))
+
+    compileOnly("com.electronwill.night-config:toml:3.6.7")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+tasks {
+    compileJava {
+        options.encoding = "UTF-8"
+    }
+}

--- a/addons/SkylliaIslandValue/readme.md
+++ b/addons/SkylliaIslandValue/readme.md
@@ -1,0 +1,349 @@
+# 🏝️ SkylliaIslandLevel
+
+> **Addon plugin for Skyllia** — Assign a **score** and a **level** to each island based on the blocks it contains.
+
+> ⚠️ **This plugin is currently in beta.** Bugs may be present. Please report them via Discord.
+
+---
+
+## 📋 Table of Contents
+
+1. [Overview](#overview)
+2. [Requirements](#requirements)
+3. [Installation](#installation)
+4. [How It Works](#how-it-works)
+5. [Configuration](#configuration)
+6. [Commands](#commands)
+7. [Permissions](#permissions)
+8. [PlaceholderAPI](#placeholderapi)
+9. [Advanced Configuration Examples](#advanced-configuration-examples)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+**SkylliaIslandLevel** is an addon for the [Skyllia](https://modrinth.com/plugin/skyllia) plugin. It automatically calculates the **value** of each skyblock island by scanning its blocks, then converts that raw score into a **readable level** using a fully customizable formula.
+
+**What this plugin does:**
+- Periodically scans the islands of online players
+- Assigns a value (score) to each block type according to your configuration
+- Calculates a level from a configurable mathematical formula
+- Exposes an island leaderboard, viewable in-game and via PlaceholderAPI
+- Stores score and level directly in Skyllia's persistent data (no external database required)
+
+---
+
+## Requirements
+
+| Dependency                                                                | Minimum Version                         | Required     |
+|---------------------------------------------------------------------------|-----------------------------------------|--------------|
+| Paper or Folia                                                            | 1.20.5+                                 | ✅            |
+| Java                                                                      | 21+                                     | ✅            |
+| [Skyllia](https://modrinth.com/plugin/skyllia)                            | Must support `getCountAllBlocksInChunk` | ✅            |
+| [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/) | Any recent version                      | ❌ (optional) |
+
+> **Folia note:** The plugin natively supports Folia by using the `RegionScheduler` for chunk scanning.
+
+---
+
+## Installation
+
+1. Download the `SkylliaIslandValue-X.X-all.jar` file from the official repository.
+2. Place the `.jar` in your `plugins/` folder.
+3. Make sure **Skyllia** is already present in `plugins/`.
+4. Start or restart your server.
+5. The plugin automatically generates its configuration file at `plugins/SkylliaIslandLevel/config/config.toml`.
+
+---
+
+## How It Works
+
+### Automatic Scan Cycle
+
+Every N seconds (configurable, default: **300 s**), the plugin:
+
+1. Retrieves the list of online players.
+2. For each player, identifies their island via `SkylliaAPI`.
+3. Determines all chunks covered by the island (chunk radius = `ceil(island_size / 16)`).
+4. Scans each chunk one by one, counting blocks via `getCountAllBlocksInChunk`.
+5. Multiplies each block count by its configured value → **raw score**.
+6. Applies the level formula → **calculated level**.
+7. Saves the score and level into the island's persistent data.
+
+### Data Storage
+
+Data is stored in Skyllia's **PersistentData** system (key `skylliaislandlevel:data`), under two entries:
+- `score` (Double) — weighted raw score
+- `level` (Long) — calculated level
+
+No external database is required.
+
+---
+
+## Configuration
+
+The configuration file is located at:
+
+```
+plugins/SkylliaIslandLevel/config/config.toml
+```
+
+### Default File
+
+```toml
+[island-level]
+# Mathematical formula to calculate the level from the score.
+# Available variables: score, level, size
+# Available functions: FLOOR, SQRT, CEIL, ABS, POW, LOG, MIN, MAX, ...
+level-expression = "FLOOR(SQRT(score / 10))"
+
+# Minimum guaranteed level (no island can drop below this)
+min-level = 0
+
+# Interval (in seconds) between two automatic scans of online islands
+timer-interval-seconds = 300
+
+# Cache validity duration for the Top leaderboard (in seconds)
+timer-interval-seconds-top = 120
+
+[blocks]
+# Assign each block type a value (positive decimal number)
+# Use Bukkit names in UPPERCASE
+DIRT = 1
+GRASS_BLOCK = 2
+STONE = 3
+```
+
+### Parameter Reference
+
+#### `level-expression`
+
+Formula evaluated by [EvalEx](https://github.com/ezylang/EvalEx). It receives three variables:
+
+| Variable | Type     | Description                                 |
+|----------|----------|---------------------------------------------|
+| `score`  | `double` | Raw score calculated from blocks            |
+| `level`  | `long`   | Current island level (before recalculation) |
+| `size`   | `double` | Island size (radius) in blocks              |
+
+**Formula examples:**
+
+```toml
+# Simple square root (default)
+level-expression = "FLOOR(SQRT(score / 10))"
+
+# Logarithmic progression (level increases more slowly)
+level-expression = "FLOOR(LOG(score + 1, 2))"
+
+# Linear formula with tiers every 1000 points
+level-expression = "FLOOR(score / 1000)"
+
+# Formula incorporating island size
+level-expression = "FLOOR(SQRT(score / 10) * (size / 100))"
+```
+
+> **PlaceholderAPI integration in the formula:** You can include PAPI placeholders inside `level-expression`. They are resolved numerically for the relevant island before evaluation.
+>
+> Example: `"FLOOR(SQRT(score / 10) + %skyllia_island_members%)"`
+
+#### `timer-interval-seconds`
+
+Time between two automatic scan passes. Setting this to `0` disables automatic scanning (players will need to use `/island level scan` manually).
+
+#### `[blocks]`
+
+Each entry follows the format:
+
+```toml
+BUKKIT_NAME = value
+```
+
+Invalid names (non-existent block in 1.20.5+) are ignored with a warning in the logs. Zero or negative values are also ignored.
+
+**Example of a more complete block configuration:**
+
+```toml
+[blocks]
+# Common — low value
+DIRT = 1
+GRAVEL = 1
+SAND = 1
+GRASS_BLOCK = 2
+
+# Stone and basic ores
+STONE = 3
+COBBLESTONE = 2
+ANDESITE = 2
+GRANITE = 2
+DIORITE = 2
+IRON_ORE = 5
+COPPER_ORE = 4
+COAL_ORE = 3
+
+# Rare ores
+GOLD_ORE = 10
+DIAMOND_ORE = 20
+EMERALD_ORE = 25
+NETHERITE_BLOCK = 100
+
+# Crafted valuable blocks
+IRON_BLOCK = 30
+GOLD_BLOCK = 60
+DIAMOND_BLOCK = 150
+EMERALD_BLOCK = 175
+
+# Exotic / end-game
+BEACON = 500
+DRAGON_EGG = 1000
+```
+
+---
+
+## Commands
+
+All subcommands of this plugin are registered in Skyllia under the `/island` (or `/is`) command.
+
+| Command                    | Description                                                        |
+|----------------------------|--------------------------------------------------------------------|
+| `/island level scan`       | Manually triggers a scan of your island and displays score + level |
+| `/island level top [page]` | Displays the island leaderboard (10 entries per page)              |
+| `/island level rank`       | Displays your position in the global leaderboard                   |
+
+> A French alias is also registered: `/island niveau`.
+
+### `/island level scan` Behavior
+
+- A scan cannot be started twice simultaneously on the same island.
+- If a scan is already in progress, the player is notified.
+- At the end of the scan, the score and level are displayed directly in chat.
+
+---
+
+## Permissions
+
+| Permission                     | Description                           | Default              |
+|--------------------------------|---------------------------------------|----------------------|
+| `skyllia.island-value.command` | Access to `/island level` subcommands | `true` (all players) |
+
+---
+
+## PlaceholderAPI
+
+If PlaceholderAPI is installed, the following placeholders are automatically available. The expansion identifier is `islandlevel`.
+
+### Individual Placeholders (per player)
+
+| Placeholder           | Returned Value                              |
+|-----------------------|---------------------------------------------|
+| `%islandlevel_level%` | Level of the player's island                |
+| `%islandlevel_score%` | Raw score of the player's island            |
+| `%islandlevel_rank%`  | Player's position in the global leaderboard |
+
+### Leaderboard Placeholders (Top)
+
+| Placeholder                   | Returned Value                         |
+|-------------------------------|----------------------------------------|
+| `%islandlevel_top_<N>_name%`  | Name of the island owner at position N |
+| `%islandlevel_top_<N>_level%` | Level of the island at position N      |
+| `%islandlevel_top_<N>_score%` | Score of the island at position N      |
+
+Replace `<N>` with an integer (e.g. `%islandlevel_top_1_name%` = 1st place).
+
+### Cache Notes
+
+Values are cached to avoid repeated database reads. The cache expires according to `timer-interval-seconds-top`. If a value is missing from the cache at request time, the last known value from the database is returned immediately while an asynchronous refresh is triggered in the background.
+
+---
+
+## Advanced Configuration Examples
+
+### Competitive Server — High values, frequent scans
+
+```toml
+[island-level]
+level-expression = "FLOOR(SQRT(score / 50))"
+min-level = 0
+timer-interval-seconds = 120
+timer-interval-seconds-top = 60
+
+[blocks]
+NETHERITE_BLOCK = 2000
+BEACON = 1000
+DIAMOND_BLOCK = 500
+EMERALD_BLOCK = 400
+GOLD_BLOCK = 200
+IRON_BLOCK = 100
+DIAMOND_ORE = 80
+EMERALD_ORE = 70
+GOLD_ORE = 40
+IRON_ORE = 20
+STONE = 5
+DIRT = 1
+```
+
+### Beginner Server — Gentle progression
+
+```toml
+[island-level]
+level-expression = "FLOOR(score / 100)"
+min-level = 1
+timer-interval-seconds = 600
+timer-interval-seconds-top = 300
+
+[blocks]
+DIRT = 5
+GRASS_BLOCK = 8
+STONE = 10
+COBBLESTONE = 7
+IRON_ORE = 30
+GOLD_ORE = 60
+DIAMOND_ORE = 120
+IRON_BLOCK = 200
+GOLD_BLOCK = 400
+DIAMOND_BLOCK = 800
+```
+
+### Displaying the Leaderboard in a Scoreboard (e.g. FeatherBoard)
+
+```
+<gold>🏆 Top Islands
+<yellow>1. <white>%islandlevel_top_1_name% <gray>- Lvl <green>%islandlevel_top_1_level%
+<yellow>2. <white>%islandlevel_top_2_name% <gray>- Lvl <green>%islandlevel_top_2_level%
+<yellow>3. <white>%islandlevel_top_3_name% <gray>- Lvl <green>%islandlevel_top_3_level%
+<gray>Your rank: <white>#%islandlevel_rank%
+```
+
+---
+
+## Troubleshooting
+
+### The plugin disables itself on startup with a `getCountAllBlocksInChunk` error
+
+Your version of Skyllia is too old and does not support this method. Update Skyllia to the latest version.
+
+### Levels are not updating
+
+Check that `timer-interval-seconds` is not set to `0`. If intentional, players must use `/island level scan` manually. Also verify that blocks with a non-zero value are defined under `[blocks]`.
+
+### A block in my config is being ignored
+
+The block name must exactly match the Bukkit name in UPPERCASE (e.g. `GRASS_BLOCK` not `GRASS`). Check the server logs on startup — invalid names are listed there.
+
+### The `level-expression` formula is invalid
+
+The plugin detects this on startup and logs an error. When the formula is invalid, the minimum level (`min-level`) is returned for all islands. Check your EvalEx syntax and test your formula on the [EvalEx Playground](https://ezylang.github.io/EvalEx/).
+
+### PAPI placeholders return an empty value
+
+Make sure the player actually has a Skyllia island. The expansion returns an empty string if no island is found for the player.
+
+---
+
+## Support
+
+For questions or bug reports, join the [official Discord](https://discord.gg/uUJQEB7XNN).
+
+## License
+
+SkylliaIslandLevel is released under the **MIT License**.

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/IslandLevelLoader.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/IslandLevelLoader.java
@@ -1,0 +1,27 @@
+package fr.euphyllia.skylliaislandlevel;
+
+import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
+import io.papermc.paper.plugin.loader.PluginLoader;
+import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("UnstableApiUsage")
+public class IslandLevelLoader implements PluginLoader {
+
+    @Override
+    public void classloader(@NotNull PluginClasspathBuilder classpathBuilder) {
+        MavenLibraryResolver resolver = new MavenLibraryResolver();
+
+        resolver.addRepository(new RemoteRepository.Builder("central", "default", "https://repo.papermc.io/repository/maven-public/").build());
+        resolver.addRepository(new RemoteRepository.Builder("central", "default", "https://repo.euphyllia.moe/repository/maven-public/").build());
+
+        resolver.addDependency(new Dependency(
+                new DefaultArtifact("com.ezylang:EvalEx:3.6.1"), null
+        ));
+
+        classpathBuilder.addLibrary(resolver);
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/SkylliaIslandLevel.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/SkylliaIslandLevel.java
@@ -1,0 +1,26 @@
+package fr.euphyllia.skylliaislandlevel;
+
+import fr.euphyllia.skylliaislandlevel.configuration.IslandLevelConfigLoader;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class SkylliaIslandLevel extends JavaPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(SkylliaIslandLevel.class);
+    private static SkylliaIslandLevel instance;
+
+    @Override
+    public void onEnable() {
+        instance = this;
+
+        try {
+            IslandLevelConfigLoader.init(getDataFolder());
+        } catch (Exception e) {
+            log.error("Failed to load configuration!", e);
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/SkylliaIslandLevel.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/SkylliaIslandLevel.java
@@ -1,6 +1,14 @@
 package fr.euphyllia.skylliaislandlevel;
 
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skylliaislandlevel.cache.LevelPapiCache;
+import fr.euphyllia.skylliaislandlevel.commands.IslandLevelCommand;
 import fr.euphyllia.skylliaislandlevel.configuration.IslandLevelConfigLoader;
+import fr.euphyllia.skylliaislandlevel.listener.IslandLevelListener;
+import fr.euphyllia.skylliaislandlevel.manager.LevelManager;
+import fr.euphyllia.skylliaislandlevel.papi.IslandLevelExpansion;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,18 +17,63 @@ public final class SkylliaIslandLevel extends JavaPlugin {
 
     private static final Logger log = LoggerFactory.getLogger(SkylliaIslandLevel.class);
     private static SkylliaIslandLevel instance;
+    private LevelPapiCache papiCache;
+    private LevelManager levelManager;
+
+    public static SkylliaIslandLevel getInstance() {
+        return instance;
+    }
 
     @Override
     public void onEnable() {
         instance = this;
+        log.warn("SkylliaIslandLevel is in beta version!");
+
+        try {
+            SkylliaAPI.getWorldNMS().getClass()
+                    .getMethod("getCountAllBlocksInChunk", World.class, int.class, int.class);
+        } catch (NoSuchMethodException e) {
+            log.error("Your version of Skyllia does not support getCountAllBlocksInChunk().");
+            log.error("Please update Skyllia to use SkylliaIslandLevel.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
 
         try {
             IslandLevelConfigLoader.init(getDataFolder());
         } catch (Exception e) {
             log.error("Failed to load configuration!", e);
             getServer().getPluginManager().disablePlugin(this);
-            return;
         }
 
+        papiCache = new LevelPapiCache();
+
+        levelManager = new LevelManager(this, papiCache);
+
+        SkylliaAPI.registerCommands(new IslandLevelCommand(), "level", "niveau");
+
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new IslandLevelExpansion().register();
+            log.debug("PlaceholderAPI expansion registered.");
+        }
+
+        getServer().getPluginManager().registerEvents(new IslandLevelListener(this), this);
+    }
+
+    @Override
+    public void onDisable() {
+        Bukkit.getAsyncScheduler().cancelTasks(this);
+        Bukkit.getGlobalRegionScheduler().cancelTasks(this);
+
+        IslandLevelConfigLoader.unregister();
+        instance = null;
+    }
+
+    public LevelManager getLevelManager() {
+        return levelManager;
+    }
+
+    public LevelPapiCache getPapiCache() {
+        return papiCache;
     }
 }

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/api/IslandLevelRecord.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/api/IslandLevelRecord.java
@@ -1,0 +1,13 @@
+package fr.euphyllia.skylliaislandlevel.api;
+
+import java.util.UUID;
+
+/**
+ * Holds the level snapshot of one island for top-list purposes.
+ *
+ * @param islandId UUID of the island
+ * @param score    Raw weighted block score
+ * @param level    Computed level
+ */
+public record IslandLevelRecord(UUID islandId, double score, long level) {
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/cache/LevelPapiCache.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/cache/LevelPapiCache.java
@@ -1,0 +1,143 @@
+package fr.euphyllia.skylliaislandlevel.cache;
+
+import fr.euphyllia.skyllia.api.utils.ExpiringValue;
+import fr.euphyllia.skylliaislandlevel.api.IslandLevelRecord;
+import fr.euphyllia.skylliaislandlevel.configuration.IslandLevelConfigLoader;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class LevelPapiCache {
+
+    private final ConcurrentHashMap<UUID, ExpiringValue<Double>> scoreByIsland = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, ExpiringValue<Long>> levelByIsland = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, CompletableFuture<Void>> inFlight = new ConcurrentHashMap<>();
+
+    private final AtomicReference<ExpiringValue<List<IslandLevelRecord>>> topCache = new AtomicReference<>();
+    private final AtomicReference<CompletableFuture<List<IslandLevelRecord>>> topInFlight = new AtomicReference<>();
+
+    private static <K, V> @Nullable V getIfValid(ConcurrentHashMap<K, ExpiringValue<V>> map, K key) {
+        ExpiringValue<V> ev = map.get(key);
+        if (ev == null) return null;
+        if (ev.isExpired()) {
+            map.remove(key, ev);
+            return null;
+        }
+        return ev.get();
+    }
+
+    public @Nullable Double getScoreIfValid(UUID islandId) {
+        return getIfValid(scoreByIsland, islandId);
+    }
+
+    public @Nullable Long getLevelIfValid(UUID islandId) {
+        return getIfValid(levelByIsland, islandId);
+    }
+
+    public void put(UUID islandId, double score, long level) {
+        long ttl = IslandLevelConfigLoader.config.getTimerIntervalSecondsTop();
+        scoreByIsland.put(islandId, ExpiringValue.of(score, ttl, TimeUnit.SECONDS));
+        levelByIsland.put(islandId, ExpiringValue.of(level, ttl, TimeUnit.SECONDS));
+    }
+
+    public void invalidate(UUID islandId) {
+        scoreByIsland.remove(islandId);
+        levelByIsland.remove(islandId);
+        inFlight.remove(islandId);
+        topCache.set(null);
+    }
+
+    public void clear() {
+        scoreByIsland.clear();
+        levelByIsland.clear();
+        inFlight.clear();
+        topCache.set(null);
+        topInFlight.set(null);
+    }
+
+    public double getScoreOrDefaultAndRefresh(Plugin plugin, UUID islandId,
+                                              Supplier<double[]> dbLoaderSync, double fallback) {
+        Double cached = getScoreIfValid(islandId);
+        if (cached != null) return cached;
+        refreshAsync(plugin, islandId, dbLoaderSync);
+        return fallback;
+    }
+
+    public long getLevelOrDefaultAndRefresh(Plugin plugin, UUID islandId,
+                                            Supplier<double[]> dbLoaderSync, long fallback) {
+        Long cached = getLevelIfValid(islandId);
+        if (cached != null) return cached;
+        refreshAsync(plugin, islandId, dbLoaderSync);
+        return fallback;
+    }
+
+    public void refreshAsync(Plugin plugin, UUID islandId, Supplier<double[]> dbLoaderSync) {
+        inFlight.computeIfAbsent(islandId, id -> {
+            CompletableFuture<Void> f = new CompletableFuture<>();
+            Bukkit.getAsyncScheduler().runNow(plugin, task -> {
+                try {
+                    double[] result = dbLoaderSync.get();
+                    if (result != null && result.length == 2) {
+                        put(id, result[0], (long) result[1]);
+                    }
+                    f.complete(null);
+                } catch (Throwable t) {
+                    f.completeExceptionally(t);
+                } finally {
+                    inFlight.remove(id);
+                }
+            });
+            return f;
+        });
+    }
+
+    public @Nullable List<IslandLevelRecord> getTopIfValid() {
+        ExpiringValue<List<IslandLevelRecord>> ev = topCache.get();
+        if (ev == null) return null;
+        if (ev.isExpired()) {
+            topCache.compareAndSet(ev, null);
+            return null;
+        }
+        return ev.get();
+    }
+
+    public void putTop(List<IslandLevelRecord> top) {
+        long ttl = IslandLevelConfigLoader.config.getTimerIntervalSecondsTop();
+        topCache.set(ExpiringValue.of(top, ttl, TimeUnit.SECONDS));
+    }
+
+    public List<IslandLevelRecord> getTopOrDefaultAndRefresh(Plugin plugin,
+                                                             Supplier<List<IslandLevelRecord>> dbLoaderSync,
+                                                             List<IslandLevelRecord> fallback) {
+        List<IslandLevelRecord> cached = getTopIfValid();
+        if (cached != null) return cached;
+        refreshTopAsync(plugin, dbLoaderSync);
+        return fallback;
+    }
+
+    public void refreshTopAsync(Plugin plugin, Supplier<List<IslandLevelRecord>> dbLoaderSync) {
+        if (topInFlight.get() != null) return;
+        CompletableFuture<List<IslandLevelRecord>> f = new CompletableFuture<>();
+        if (!topInFlight.compareAndSet(null, f)) return;
+
+        Bukkit.getAsyncScheduler().runNow(plugin, task -> {
+            try {
+                List<IslandLevelRecord> top = dbLoaderSync.get();
+                if (top != null) putTop(top);
+                f.complete(top);
+            } catch (Throwable t) {
+                f.completeExceptionally(t);
+            } finally {
+                topInFlight.compareAndSet(f, null);
+            }
+        });
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/commands/IslandLevelCommand.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/commands/IslandLevelCommand.java
@@ -60,8 +60,8 @@ public class IslandLevelCommand implements SubCommandInterface {
         ConfigLoader.language.sendMessage(player, "addons.island-value.scan-started");
         boolean started = SkylliaIslandLevel.getInstance().getLevelManager().triggerScan(island, (score, level) -> {
             ConfigLoader.language.sendMessage(player, "addons.island-value.scan-completed", Map.of(
-                    "score", String.format("%.2f", score),
-                    "level", Long.toString(level)
+                    "%score%", String.format("%.2f", score),
+                    "%level%", Long.toString(level)
             ));
         });
 

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/commands/IslandLevelCommand.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/commands/IslandLevelCommand.java
@@ -1,0 +1,182 @@
+package fr.euphyllia.skylliaislandlevel.commands;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skylliaislandlevel.SkylliaIslandLevel;
+import fr.euphyllia.skylliaislandlevel.api.IslandLevelRecord;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class IslandLevelCommand implements SubCommandInterface {
+
+    @Override
+    public void onExecute(@NotNull Plugin plugin, @NotNull CommandSender sender, @NonNull @NotNull String[] args) {
+        if (!sender.hasPermission(permission())) {
+            ConfigLoader.language.sendMessage(sender, "addons.island-value.no-permissions");
+            return;
+        }
+
+        if (args.length == 0) {
+            ConfigLoader.language.sendMessage(sender, "addons.island-value.level-command-usage");
+            return;
+        }
+
+        if (!(sender instanceof Player player)) {
+            ConfigLoader.language.sendMessage(sender, "addons.island-value.player-only-command");
+            return;
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "scan" -> handleScan(player);
+            case "top" -> handleTop(player, args);
+            case "rank" -> handleRank(player);
+            default -> ConfigLoader.language.sendMessage(player, "addons.island-value.level-command-usage");
+        }
+    }
+
+    private void handleScan(Player player) {
+        Island island = SkylliaAPI.getIslandByPlayerId(player.getUniqueId());
+        if (island == null) {
+            ConfigLoader.language.sendMessage(player, "addons.island-value.not-on-island");
+            return;
+        }
+
+        if (SkylliaIslandLevel.getInstance().getLevelManager().isScanning(island.getId())) {
+            ConfigLoader.language.sendMessage(player, "addons.island-value.already-scanning");
+            return;
+        }
+
+        ConfigLoader.language.sendMessage(player, "addons.island-value.scan-started");
+        boolean started = SkylliaIslandLevel.getInstance().getLevelManager().triggerScan(island, (score, level) -> {
+            ConfigLoader.language.sendMessage(player, "addons.island-value.scan-completed", Map.of(
+                    "score", String.format("%.2f", score),
+                    "level", Long.toString(level)
+            ));
+        });
+
+        if (!started) {
+            ConfigLoader.language.sendMessage(player, "addons.island-value.scan-start-failed");
+        }
+    }
+
+    private void handleTop(Player sender, String[] args) {
+        int page = 1;
+        if (args.length >= 2) {
+            try {
+                page = Integer.parseInt(args[1]);
+                if (page < 1) page = 1;
+            } catch (NumberFormatException e) {
+                ConfigLoader.language.sendMessage(sender, "addons.island-value.invalid-page",
+                        Map.of("%input%", args[1]));
+                return;
+            }
+        }
+
+        final int pageSize = 10;
+
+        List<IslandLevelRecord> top = SkylliaIslandLevel.getInstance().getLevelManager().getTopIslands();
+
+        int totalEntries = top.size();
+        int maxPage = Math.max(1, (int) Math.ceil(totalEntries / (double) pageSize));
+        int safePage = Math.min(page, maxPage);
+        int start = (safePage - 1) * pageSize;
+        int end = Math.min(start + pageSize, totalEntries);
+
+        ConfigLoader.language.sendMessage(sender, "addons.island-value.top-header", Map.of(
+                "%page%", String.valueOf(safePage),
+                "%max_page%", String.valueOf(maxPage),
+                "%total%", String.valueOf(totalEntries)
+        ), false);
+
+        if (totalEntries == 0) {
+            ConfigLoader.language.sendMessage(sender, "addons.island-value.top-empty");
+            return;
+        }
+
+        for (int i = start; i < end; i++) {
+            IslandLevelRecord entry = top.get(i);
+            Island island = SkylliaAPI.getIslandByIslandId(entry.islandId());
+
+            String ownerName = "Unknown";
+            if (island != null && island.getOwner() != null) {
+                String n = island.getOwner().getLastKnowName();
+                if (n != null) ownerName = n;
+            }
+
+            ConfigLoader.language.sendMessage(sender, "addons.island-value.top-line", Map.of(
+                    "%rank%", String.valueOf(i + 1),
+                    "%owner%", ownerName,
+                    "%level%", String.valueOf(entry.level()),
+                    "%score%", String.format("%.0f", entry.score())
+            ), false);
+        }
+    }
+
+    private void handleRank(Player player) {
+        Island island = SkylliaAPI.getIslandByPlayerId(player.getUniqueId());
+        if (island == null) {
+            ConfigLoader.language.sendMessage(player, "addons.island-value.not-on-island");
+            return;
+        }
+
+        List<IslandLevelRecord> top = SkylliaIslandLevel.getInstance().getLevelManager().getTopIslands();
+
+        final UUID islandId = island.getId();
+        int myRank = 0;
+        IslandLevelRecord myEntry = null;
+
+        for (int i = 0; i < top.size(); i++) {
+            if (top.get(i).islandId().equals(islandId)) {
+                myRank = i + 1;
+                myEntry = top.get(i);
+                break;
+            }
+        }
+
+        if (myRank > 0) {
+            ConfigLoader.language.sendMessage(player, "addons.island-value.rank-self", Map.of(
+                    "%rank%", String.valueOf(myRank),
+                    "%owner%", island.getOwner() != null ? island.getOwner().getLastKnowName() : "Unknown",
+                    "%level%", String.valueOf(myEntry.level()),
+                    "%score%", String.format("%.0f", myEntry.score())
+            ), false);
+        } else {
+            ConfigLoader.language.sendMessage(player, "addons.island-value.rank-self-unranked", Map.of(
+                    "%owner%", island.getOwner() != null ? island.getOwner().getLastKnowName() : "Unknown"
+            ));
+        }
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NonNull @NotNull String[] args) {
+        if (args.length == 1) {
+            String partial = args[0].toLowerCase();
+            return Stream.of("scan", "top", "rank")
+                    .filter(s -> s.startsWith(partial))
+                    .collect(Collectors.toList());
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("top")) {
+            String partial = args[1];
+            return Stream.of("1", "2", "3", "4", "5")
+                    .filter(s -> s.startsWith(partial))
+                    .collect(Collectors.toList());
+        }
+        return List.of();
+    }
+
+    @Override
+    public String permission() {
+        return "skyllia.island-value.command";
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigLoader.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigLoader.java
@@ -5,6 +5,8 @@ import fr.euphyllia.skyllia.api.SkylliaAPI;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 public class IslandLevelConfigLoader {
 
@@ -37,5 +39,11 @@ public class IslandLevelConfigLoader {
         config.loadConfig();
 
         SkylliaAPI.getConfigRegistry().registerConfig(config);
+    }
+
+    public static void unregister() {
+        if (config != null) {
+            SkylliaAPI.getConfigRegistry().unregisterConfig(config);
+        }
     }
 }

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigLoader.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigLoader.java
@@ -1,0 +1,41 @@
+package fr.euphyllia.skylliaislandlevel.configuration;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+
+import java.io.File;
+import java.io.IOException;
+
+public class IslandLevelConfigLoader {
+
+    public static IslandLevelConfigManager config;
+
+    public static void init(File dataFolder) throws Exception {
+        File configDir = new File(dataFolder, "config");
+        //noinspection ResultOfMethodCallIgnored
+        configDir.mkdirs();
+
+        File configFile = new File(configDir, "config.toml");
+        if (!configFile.exists()) {
+            try (InputStream in = IslandLevelConfigLoader.class
+                    .getResourceAsStream("/config/config.toml")) {
+                if (in != null) {
+                    Files.copy(in, configFile.toPath());
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to copy default config", e);
+            }
+        }
+
+        CommentedFileConfig cfg = CommentedFileConfig.builder(configFile)
+                .sync()
+                .autosave()
+                .build();
+        cfg.load();
+
+        config = new IslandLevelConfigManager(cfg);
+        config.loadConfig();
+
+        SkylliaAPI.getConfigRegistry().registerConfig(config);
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigManager.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigManager.java
@@ -5,11 +5,24 @@ import com.electronwill.nightconfig.core.io.IndentStyle;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import com.electronwill.nightconfig.toml.TomlWriter;
 import fr.euphyllia.skyllia.api.configuration.IConfigurationProvider;
+import org.bukkit.Material;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
 
 public class IslandLevelConfigManager implements IConfigurationProvider {
 
+    private static final Logger log = LoggerFactory.getLogger(IslandLevelConfigManager.class);
     private final CommentedFileConfig config;
     private boolean changed = false;
+    private Map<Material, Double> blockValues = Collections.emptyMap();
+    private String levelExpression = "FLOOR(SQRT(score / 10))";
+    private long minLevel = 0L;
+    private int timerIntervalSeconds = 60;
+    private int timerIntervalSecondsTop = 120;
 
     public IslandLevelConfigManager(CommentedFileConfig cfg) {
         this.config = cfg;
@@ -19,12 +32,39 @@ public class IslandLevelConfigManager implements IConfigurationProvider {
     public void loadConfig() throws Exception {
         changed = false;
 
+        blockValues = loadBlockValues();
+        levelExpression = getOrSetDefault("island-level.level-expression", levelExpression, String.class);
+        minLevel = getOrSetDefault("island-level.min-level", minLevel, Long.class);
+        timerIntervalSeconds = getOrSetDefault("island-level.timer-interval-seconds", timerIntervalSeconds, Integer.class);
+        timerIntervalSecondsTop = getOrSetDefault("island-level.timer-interval-seconds-top", timerIntervalSeconds, Integer.class);
 
         if (changed) {
             TomlWriter tomlWriter = new TomlWriter();
             tomlWriter.setIndent(IndentStyle.NONE);
             tomlWriter.write(config, config.getFile(), WritingMode.REPLACE);
         }
+    }
+
+    private Map<Material, Double> loadBlockValues() {
+        EnumMap<Material, Double> values = new EnumMap<>(Material.class);
+        com.electronwill.nightconfig.core.Config blockSection = config.get("blocks");
+        if (blockSection == null) {
+            log.warn("No [blocks] section found in config, island levels will not be calculated based on blocks.");
+            return Collections.unmodifiableMap(values);
+        }
+        for (Map.Entry<String, Object> entry : blockSection.valueMap().entrySet()) {
+            String matName = entry.getKey().toUpperCase();
+            try {
+                Material mat = Material.valueOf(matName);
+                double val = ((Number) entry.getValue()).doubleValue();
+                if (val > 0) values.put(mat, val);
+            } catch (IllegalArgumentException e) {
+                log.warn("Invalid material '{}' in config blocks section, skipping.", matName);
+            }
+        }
+
+        log.info("Loaded {} block values from config.", values.size());
+        return Collections.unmodifiableMap(values);
     }
 
     @Override
@@ -48,11 +88,31 @@ public class IslandLevelConfigManager implements IConfigurationProvider {
 
     @Override
     public boolean canReloadFromDisk() {
-        return false;
+        return true;
     }
 
     @Override
     public void reloadFromDisk() {
-        IConfigurationProvider.super.reloadFromDisk();
+        config.load();
+    }
+
+    public Map<Material, Double> getBlockValues() {
+        return blockValues;
+    }
+
+    public String getLevelExpression() {
+        return levelExpression;
+    }
+
+    public long getMinLevel() {
+        return minLevel;
+    }
+
+    public int getTimerIntervalSeconds() {
+        return timerIntervalSeconds;
+    }
+
+    public int getTimerIntervalSecondsTop() {
+        return timerIntervalSecondsTop;
     }
 }

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigManager.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/configuration/IslandLevelConfigManager.java
@@ -1,0 +1,58 @@
+package fr.euphyllia.skylliaislandlevel.configuration;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.electronwill.nightconfig.core.io.IndentStyle;
+import com.electronwill.nightconfig.core.io.WritingMode;
+import com.electronwill.nightconfig.toml.TomlWriter;
+import fr.euphyllia.skyllia.api.configuration.IConfigurationProvider;
+
+public class IslandLevelConfigManager implements IConfigurationProvider {
+
+    private final CommentedFileConfig config;
+    private boolean changed = false;
+
+    public IslandLevelConfigManager(CommentedFileConfig cfg) {
+        this.config = cfg;
+    }
+
+    @Override
+    public void loadConfig() throws Exception {
+        changed = false;
+
+
+        if (changed) {
+            TomlWriter tomlWriter = new TomlWriter();
+            tomlWriter.setIndent(IndentStyle.NONE);
+            tomlWriter.write(config, config.getFile(), WritingMode.REPLACE);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getOrSetDefault(String path, T defaultValue, Class<T> expectedClass) {
+        Object value = config.get(path);
+        if (value == null) {
+            config.set(path, defaultValue);
+            changed = true;
+            return defaultValue;
+        }
+        if (expectedClass.isInstance(value)) return (T) value;
+        return switch (value) {
+            case Integer i when expectedClass == Long.class -> (T) Long.valueOf(i);
+            case Double d when expectedClass == Float.class -> (T) Float.valueOf(d.floatValue());
+            case Integer i when expectedClass == Double.class -> (T) Double.valueOf(i);
+            default -> throw new IllegalStateException("Cannot convert value at '" + path + "' from "
+                    + value.getClass().getSimpleName() + " to " + expectedClass.getSimpleName());
+        };
+    }
+
+    @Override
+    public boolean canReloadFromDisk() {
+        return false;
+    }
+
+    @Override
+    public void reloadFromDisk() {
+        IConfigurationProvider.super.reloadFromDisk();
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/listener/IslandLevelListener.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/listener/IslandLevelListener.java
@@ -1,0 +1,44 @@
+package fr.euphyllia.skylliaislandlevel.listener;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.database.IslandCustomDataQuery;
+import fr.euphyllia.skyllia.api.event.SkyblockCreateEvent;
+import fr.euphyllia.skyllia.api.event.SkyblockLoadEvent;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skylliaislandlevel.SkylliaIslandLevel;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.persistence.PersistentDataType;
+
+public class IslandLevelListener implements Listener {
+
+    private static final String KEY_SCORE = "score";
+    private static final String KEY_LEVEL = "level";
+    private final NamespacedKey namespaceKey;
+    private final IslandCustomDataQuery customDataQuery;
+
+    public IslandLevelListener(SkylliaIslandLevel plugin) {
+        this.namespaceKey = new NamespacedKey(plugin, "data");
+        this.customDataQuery = SkylliaAPI.getIslandCustomDataQuery();
+    }
+
+    @EventHandler
+    public void onIslandLoad(SkyblockLoadEvent event) {
+        initIsland(event.getIsland());
+    }
+
+    @EventHandler
+    public void onIslandCreate(SkyblockCreateEvent event) {
+        initIsland(event.getIsland());
+    }
+
+    private void initIsland(Island island) {
+        if (!customDataQuery.has(namespaceKey, island, KEY_SCORE)) {
+            customDataQuery.set(namespaceKey, island, KEY_SCORE, PersistentDataType.DOUBLE, 0.0);
+        }
+        if (!customDataQuery.has(namespaceKey, island, KEY_LEVEL)) {
+            customDataQuery.set(namespaceKey, island, KEY_LEVEL, PersistentDataType.LONG, 0L);
+        }
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/manager/LevelFormulaEvaluator.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/manager/LevelFormulaEvaluator.java
@@ -1,0 +1,168 @@
+package fr.euphyllia.skylliaislandlevel.manager;
+
+import com.ezylang.evalex.Expression;
+import com.ezylang.evalex.config.ExpressionConfiguration;
+import com.ezylang.evalex.data.EvaluationValue;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LevelFormulaEvaluator {
+
+    private static final Pattern PAPI_PATTERN = Pattern.compile("%([^%]+)%");
+    private static final Logger log = LoggerFactory.getLogger(LevelFormulaEvaluator.class);
+
+    private static final Set<String> BUILTIN_VARS = Set.of("score", "level", "size");
+
+    private static final ExpressionConfiguration EVAL_CONFIG =
+            ExpressionConfiguration.defaultConfiguration();
+
+    private volatile String expressionStr;
+    private volatile boolean valid = false;
+    private volatile boolean papiAvailable = false;
+
+    public LevelFormulaEvaluator(String expression) {
+        reload(expression);
+    }
+
+    private static double evaluateInternal(String rawExpr, List<PapiVar> papiVars, double score, long currentLevel, double islandSize) throws Exception {
+        String expr = substituteTokens(rawExpr, papiVars);
+
+        Expression expression = new Expression(expr, EVAL_CONFIG)
+                .with("score", BigDecimal.valueOf(score))
+                .and("level", BigDecimal.valueOf(currentLevel))
+                .and("size", BigDecimal.valueOf(islandSize));
+
+        for (PapiVar v : papiVars) {
+            expression = expression.and(v.varName, BigDecimal.valueOf(v.value));
+        }
+
+        EvaluationValue result = expression.evaluate();
+        return result.getNumberValue().doubleValue();
+    }
+
+    private static String substituteTokens(String rawExpr, List<PapiVar> papiVars) {
+        String expr = rawExpr;
+        for (PapiVar v : papiVars) {
+            expr = expr.replace("%" + v.placeholder + "%", v.varName);
+        }
+        return expr;
+    }
+
+    private static List<PapiVar> extractPapiVars(String expression) {
+        List<PapiVar> vars = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        Matcher m = PAPI_PATTERN.matcher(expression);
+
+        while (m.find()) {
+            String placeholder = m.group(1);
+            String varName = sanitize(placeholder);
+
+            if (BUILTIN_VARS.contains(varName)) {
+                continue;
+            }
+            if (seen.add(varName)) {
+                vars.add(new PapiVar(placeholder, varName, 0.0));
+            }
+        }
+        return vars;
+    }
+
+    private static double parseDouble(String raw, String placeholder) {
+        if (raw == null || raw.isBlank()) return 0.0;
+        String cleaned = raw.replaceAll("§[0-9a-fk-orxA-FK-ORX]", "").trim();
+        try {
+            return Double.parseDouble(cleaned);
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0.0;
+        }
+    }
+
+    static String sanitize(String placeholder) {
+        return "p_" + placeholder.replaceAll("[^a-zA-Z0-9_]", "_");
+    }
+
+    private static OfflinePlayer resolveOwner(Island island) {
+        if (island.getOwner() == null) return Bukkit.getOfflinePlayer(UUID.randomUUID());
+        return Bukkit.getOfflinePlayer(island.getOwner().getMojangId());
+    }
+
+    public synchronized void reload(String expression) {
+        this.expressionStr = expression;
+        this.papiAvailable = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
+        try {
+            List<PapiVar> dummyVars = extractPapiVars(expression);
+            evaluateInternal(expression, dummyVars, 0.0, 0L, 0.0);
+            valid = true;
+        } catch (Exception e) {
+            log.error("[SkylliaIslandLevel] Invalid level_expression '{}'", expression, e);
+            valid = false;
+        }
+    }
+
+    public long evaluate(double score, long currentLevel, long minLevel, Island island) {
+        if (!valid) return minLevel;
+        try {
+            List<PapiVar> papiVars = resolvePapiVars(expressionStr, island);
+            double result = evaluateInternal(expressionStr, papiVars, score, currentLevel, island.getSize());
+            if (Double.isNaN(result) || Double.isInfinite(result)) return minLevel;
+            return Math.max(minLevel, (long) result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return minLevel;
+        }
+    }
+
+    public long evaluate(double score, long currentLevel, long minLevel) {
+        if (!valid) return minLevel;
+        try {
+            double result = evaluateInternal(expressionStr, Collections.emptyList(), score, currentLevel, 0.0);
+            if (Double.isNaN(result) || Double.isInfinite(result)) return minLevel;
+            return Math.max(minLevel, (long) result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return minLevel;
+        }
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    private List<PapiVar> resolvePapiVars(String expression, Island island) {
+        List<PapiVar> extracted = extractPapiVars(expression);
+        if (extracted.isEmpty()) return extracted;
+
+        if (!papiAvailable) {
+            return extracted;
+        }
+
+        OfflinePlayer ownerPlayer = resolveOwner(island);
+        for (PapiVar var : extracted) {
+            String raw = PlaceholderAPI.setPlaceholders(ownerPlayer, "%" + var.placeholder + "%");
+            var.value = parseDouble(raw, var.placeholder);
+        }
+        return extracted;
+    }
+
+    private static final class PapiVar {
+        final String placeholder; // raw token between %%  e.g. "skyllia_island_members"
+        final String varName;     // sanitised EvalEx variable name  e.g. "p_skyllia_island_members"
+        double value;             // resolved numeric value (0.0 until resolved)
+
+        PapiVar(String placeholder, String varName, double value) {
+            this.placeholder = placeholder;
+            this.varName = varName;
+            this.value = value;
+        }
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/manager/LevelManager.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/manager/LevelManager.java
@@ -1,0 +1,182 @@
+package fr.euphyllia.skylliaislandlevel.manager;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.database.IslandCustomDataQuery;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skylliaislandlevel.SkylliaIslandLevel;
+import fr.euphyllia.skylliaislandlevel.api.IslandLevelRecord;
+import fr.euphyllia.skylliaislandlevel.cache.LevelPapiCache;
+import fr.euphyllia.skylliaislandlevel.configuration.IslandLevelConfigLoader;
+import fr.euphyllia.skylliaislandlevel.scanner.IslandScanner;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class LevelManager {
+
+    private static final Logger log = LoggerFactory.getLogger(LevelManager.class);
+    private static final String KEY_SCORE = "score";
+    private static final String KEY_LEVEL = "level";
+    private final Set<UUID> scanningIslands = ConcurrentHashMap.newKeySet();
+    private final IslandScanner scanner;
+    private final LevelPapiCache papiCache;
+    private final LevelFormulaEvaluator evaluator;
+
+    private final NamespacedKey namespaceKey;
+    private final SkylliaIslandLevel plugin;
+
+    public LevelManager(SkylliaIslandLevel plugin, LevelPapiCache papiCache) {
+        this.plugin = plugin;
+        this.papiCache = papiCache;
+        this.namespaceKey = new NamespacedKey(plugin, "data");
+        this.scanner = new IslandScanner(plugin);
+        this.evaluator = new LevelFormulaEvaluator(
+                IslandLevelConfigLoader.config.getLevelExpression()
+        );
+        startTimer();
+    }
+
+    private void startTimer() {
+        int intervalSecs = IslandLevelConfigLoader.config.getTimerIntervalSeconds();
+        if (intervalSecs <= 0) return;
+        Bukkit.getAsyncScheduler().runAtFixedRate(plugin, scheduledTask -> {
+            try {
+                autoScanAll();
+            } catch (Throwable t) {
+                log.error("Error occurred during scheduled island scan", t);
+            }
+        }, 1, intervalSecs, TimeUnit.SECONDS);
+    }
+
+    private void autoScanAll() {
+        var onlinePlayers = Bukkit.getOnlinePlayers();
+        if (onlinePlayers.isEmpty()) return;
+
+        List<Island> islandsLoaded = new ArrayList<>();
+        for (Player p : onlinePlayers) {
+            Island island = SkylliaAPI.getIslandByPlayerId(p.getUniqueId());
+            if (island != null && !islandsLoaded.contains(island)) {
+                islandsLoaded.add(island);
+            }
+        }
+
+        for (Island island : islandsLoaded) {
+            if (scanningIslands.contains(island.getId())) continue;
+            triggerScan(island, null);
+        }
+    }
+
+    public boolean triggerScan(Island island, ScanCallback callback) {
+        if (!scanningIslands.add(island.getId())) {
+            log.warn("Scan for island '{}' is already in progress, skipping trigger.", island.getId());
+            return false;
+        }
+
+        World world = pickWorld();
+
+        if (world == null) {
+            scanningIslands.remove(island.getId());
+            log.warn("Failed to find a world for scanning island '{}', aborting scan.", island.getId());
+            return false;
+        }
+
+        scanner.scanIsland(island, world).whenComplete((score, err) -> {
+            try {
+                if (err != null) {
+                    log.error("Scan error for island {}", island.getId(), err);
+                    return;
+                }
+                long currentLevel = getStoredLevel(island);
+                long newLevel = evaluator.evaluate(
+                        score, currentLevel, IslandLevelConfigLoader.config.getMinLevel(), island
+                );
+                log.debug("[LevelManager] score={} currentLevel={} newLevel={} formulaValid={}",
+                        score, currentLevel, newLevel, evaluator.isValid());
+                saveData(island, score, newLevel);
+                papiCache.invalidate(island.getId());
+
+                if (callback != null) {
+                    callback.onComplete(score, newLevel);
+                }
+            } finally {
+                scanningIslands.remove(island.getId());
+            }
+        });
+
+        return true;
+    }
+
+    public boolean isScanning(UUID islandId) {
+        return scanningIslands.contains(islandId);
+    }
+
+    public double getStoredScore(Island island) {
+        IslandCustomDataQuery q = SkylliaAPI.getIslandCustomDataQuery();
+        try {
+            Double raw = q.get(namespaceKey, island, KEY_SCORE, PersistentDataType.DOUBLE);
+            return raw != null ? raw : 0.0;
+        } catch (Exception e) {
+            q.set(namespaceKey, island, KEY_SCORE, PersistentDataType.DOUBLE, 0.0);
+            return 0.0;
+        }
+    }
+
+
+    public long getStoredLevel(Island island) {
+        IslandCustomDataQuery q = SkylliaAPI.getIslandCustomDataQuery();
+        try {
+            Long raw = q.get(namespaceKey, island, KEY_LEVEL, PersistentDataType.LONG);
+            return raw != null ? raw : 0L;
+        } catch (Exception e) {
+            q.set(namespaceKey, island, KEY_LEVEL, PersistentDataType.LONG, 0L);
+            return 0L;
+        }
+    }
+
+    public List<IslandLevelRecord> getTopIslands() {
+        List<IslandLevelRecord> cached = papiCache.getTopIfValid();
+        if (cached != null) return cached;
+
+        List<IslandLevelRecord> top = SkylliaAPI.getAllIslandsValid().stream()
+                .map(island -> {
+                    double score = getStoredScore(island);
+                    long level = getStoredLevel(island);
+                    papiCache.put(island.getId(), score, level);
+                    return new IslandLevelRecord(island.getId(), score, level);
+                })
+                .sorted(Comparator.comparingLong(IslandLevelRecord::level).reversed())
+                .collect(Collectors.toList());
+
+        papiCache.putTop(top);
+        return top;
+    }
+
+
+    private void saveData(Island island, double score, long level) {
+        IslandCustomDataQuery q = SkylliaAPI.getIslandCustomDataQuery();
+        q.set(namespaceKey, island, KEY_SCORE, PersistentDataType.DOUBLE, score);
+        q.set(namespaceKey, island, KEY_LEVEL, PersistentDataType.LONG, level);
+        log.debug("[SkylliaIslandLevel] Island {} → score={}, level={}", island.getId(), score, level);
+    }
+
+    private World pickWorld() {
+        for (World w : Bukkit.getWorlds()) {
+            if (SkylliaAPI.isWorldSkyblock(w)) return w;
+        }
+        return null;
+    }
+
+    @FunctionalInterface
+    public interface ScanCallback {
+        void onComplete(double score, long level);
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/papi/IslandLevelExpansion.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/papi/IslandLevelExpansion.java
@@ -1,0 +1,158 @@
+package fr.euphyllia.skylliaislandlevel.papi;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.Players;
+import fr.euphyllia.skylliaislandlevel.SkylliaIslandLevel;
+import fr.euphyllia.skylliaislandlevel.api.IslandLevelRecord;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+public class IslandLevelExpansion extends PlaceholderExpansion {
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "islandlevel";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "Euphyllia";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return SkylliaIslandLevel.getInstance().getPluginMeta().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public @NotNull List<String> getPlaceholders() {
+        return List.of(
+                "level",
+                "score",
+                "rank",
+                "top_<n>_name",
+                "top_<n>_level",
+                "top_<n>_score"
+        );
+    }
+
+    @Override
+    public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
+        if (player == null || !player.hasPlayedBefore()) return "";
+
+        String key = params.toLowerCase(Locale.ROOT);
+
+        // --- Top-list placeholders ---
+        if (key.startsWith("top_")) {
+            return resolveTopPlaceholder(key);
+        }
+
+        UUID playerId = player.getUniqueId();
+        Island island = SkylliaAPI.getIslandByPlayerId(playerId);
+        if (island == null) return "";
+
+        UUID islandId = island.getId();
+
+        return switch (key) {
+            case "level" -> String.valueOf(getCachedLevel(island, islandId));
+            case "score" -> String.valueOf(getCachedScore(island, islandId));
+            case "rank" -> {
+                int rank = computeRank(islandId);
+                yield rank > 0 ? String.valueOf(rank) : "";
+            }
+            default -> null;
+        };
+    }
+
+    private long getCachedLevel(Island island, UUID islandId) {
+        return SkylliaIslandLevel.getInstance().getPapiCache()
+                .getLevelOrDefaultAndRefresh(
+                        SkylliaIslandLevel.getInstance(),
+                        islandId,
+                        () -> loadFromDb(island),
+                        SkylliaIslandLevel.getInstance().getLevelManager().getStoredLevel(island)
+                );
+    }
+
+    private double getCachedScore(Island island, UUID islandId) {
+        return SkylliaIslandLevel.getInstance().getPapiCache()
+                .getScoreOrDefaultAndRefresh(
+                        SkylliaIslandLevel.getInstance(),
+                        islandId,
+                        () -> loadFromDb(island),
+                        SkylliaIslandLevel.getInstance().getLevelManager().getStoredScore(island)
+                );
+    }
+
+    private double[] loadFromDb(Island island) {
+        double score = SkylliaIslandLevel.getInstance().getLevelManager().getStoredScore(island);
+        long level = SkylliaIslandLevel.getInstance().getLevelManager().getStoredLevel(island);
+        return new double[]{score, (double) level};
+    }
+
+    private int computeRank(UUID islandId) {
+        List<IslandLevelRecord> top = getCachedTop();
+        for (int i = 0; i < top.size(); i++) {
+            if (top.get(i).islandId().equals(islandId)) return i + 1;
+        }
+        return 0;
+    }
+
+    private @Nullable String resolveTopPlaceholder(String key) {
+        String remainder = key.substring("top_".length());
+        int underscore = remainder.indexOf('_');
+        if (underscore <= 0) return null;
+
+        int position;
+        try {
+            position = Integer.parseInt(remainder.substring(0, underscore));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        if (position <= 0) return "";
+
+        String field = remainder.substring(underscore + 1);
+
+        List<IslandLevelRecord> top = getCachedTop();
+        if (position > top.size()) return "";
+
+        IslandLevelRecord entry = top.get(position - 1);
+        return switch (field) {
+            case "name" -> resolveOwnerName(entry.islandId());
+            case "level" -> String.valueOf(entry.level());
+            case "score" -> String.valueOf(entry.score());
+            default -> null;
+        };
+    }
+
+    private String resolveOwnerName(UUID islandId) {
+        Island island = SkylliaAPI.getIslandByIslandId(islandId);
+        if (island == null) return "";
+        Players owner = island.getOwner();
+        if (owner == null) return "";
+        String name = owner.getLastKnowName();
+        return name != null ? name : "";
+    }
+
+    private List<IslandLevelRecord> getCachedTop() {
+        return SkylliaIslandLevel.getInstance().getPapiCache()
+                .getTopOrDefaultAndRefresh(
+                        SkylliaIslandLevel.getInstance(),
+                        () -> SkylliaIslandLevel.getInstance().getLevelManager().getTopIslands(),
+                        List.of()
+                );
+    }
+
+}

--- a/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/scanner/IslandScanner.java
+++ b/addons/SkylliaIslandValue/src/main/java/fr/euphyllia/skylliaislandlevel/scanner/IslandScanner.java
@@ -1,0 +1,128 @@
+package fr.euphyllia.skylliaislandlevel.scanner;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.model.Position;
+import fr.euphyllia.skylliaislandlevel.SkylliaIslandLevel;
+import fr.euphyllia.skylliaislandlevel.configuration.IslandLevelConfigLoader;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public class IslandScanner {
+
+    private static final Logger log = LoggerFactory.getLogger(IslandScanner.class);
+    private final SkylliaIslandLevel plugin;
+
+    public IslandScanner(SkylliaIslandLevel plugin) {
+        this.plugin = plugin;
+    }
+
+    public CompletableFuture<Double> scanIsland(Island island, World world) {
+        CompletableFuture<Double> result = new CompletableFuture<>();
+
+        List<int[]> chunkCoords = getIslandChunks(island);
+
+        // DEBUG
+        log.debug("[Scanner] Island {} — center chunk ({},{}) size={} → {} chunks to scan",
+                island.getId(),
+                island.getPosition().x(), island.getPosition().z(),
+                island.getSize(),
+                chunkCoords.size());
+
+        if (chunkCoords.isEmpty()) {
+            result.complete(0.0);
+            return result;
+        }
+
+        Map<Material, Double> blockValues = IslandLevelConfigLoader.config.getBlockValues();
+
+        // DEBUG
+        log.debug("[Scanner] blockValues loaded: {} entries", blockValues.size());
+
+        scanChunksRecursively(world, island, chunkCoords, 0, 0.0, blockValues, result);
+        return result;
+    }
+
+    private void scanChunksRecursively(World world, Island island, List<int[]> chunks, int index, double accumulatedScore, Map<Material, Double> blockValues, CompletableFuture<Double> resultFuture) {
+        if (index >= chunks.size()) {
+            resultFuture.complete(accumulatedScore);
+            return;
+        }
+
+        int[] coord = chunks.get(index);
+        int chunkX = coord[0];
+        int chunkZ = coord[1];
+
+        Runnable scanTask = () -> {
+            double chunkScore = 0.0;
+            try {
+                chunkScore = scoreChunk(world, chunkX, chunkZ, blockValues);
+            } catch (Throwable e) {
+                log.error("Failed to scan chunk at ({}, {}) for island '{}'", chunkX, chunkZ, island.getId(), e);
+            }
+
+            final double nextScore = accumulatedScore + chunkScore;
+            scanChunksRecursively(world, island, chunks, index + 1, nextScore, blockValues, resultFuture);
+        };
+
+        if (Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ)) {
+            scanTask.run();
+            return;
+        }
+        Bukkit.getRegionScheduler().run(plugin, world, chunkX, chunkZ, t -> scanTask.run());
+    }
+
+    private double scoreChunk(World world, int chunkX, int chunkZ, Map<Material, Double> blockValues) {
+        Map<Material, Integer> blockCounts = SkylliaAPI.getWorldNMS().getCountAllBlocksInChunk(world, chunkX, chunkZ);
+
+        if (!blockCounts.isEmpty()) {
+            log.debug("[Scanner] Chunk ({},{}) → {} block types found, sample: {}",
+                    chunkX, chunkZ, blockCounts.size(),
+                    blockCounts.entrySet().stream().limit(5)
+                            .map(e -> e.getKey() + "×" + e.getValue())
+                            .collect(java.util.stream.Collectors.joining(", ")));
+        } else {
+            log.debug("[Scanner] Chunk ({},{}) → empty", chunkX, chunkZ);
+        }
+
+        if (blockCounts.isEmpty()) return 0.0;
+
+        double score = 0.0;
+        for (Map.Entry<Material, Integer> entry : blockCounts.entrySet()) {
+            Double value = blockValues.get(entry.getKey());
+            if (value != null) {
+                score += value * entry.getValue();
+            }
+        }
+
+        if (score > 0) log.debug("[Scanner] Chunk ({},{}) → score={}", chunkX, chunkZ, score);
+
+        return score;
+    }
+
+    private List<int[]> getIslandChunks(Island island) {
+        Position pos = island.getPosition();
+        double size = island.getSize();
+
+        int centerChunkX = (pos.x() << 5) + 16;
+        int centerChunkZ = (pos.z() << 5) + 16;
+
+        int chunkRadius = (int) Math.ceil(size / 16.0);
+
+        List<int[]> result = new ArrayList<>();
+        for (int cx = centerChunkX - chunkRadius; cx <= centerChunkX + chunkRadius; cx++) {
+            for (int cz = centerChunkZ - chunkRadius; cz <= centerChunkZ + chunkRadius; cz++) {
+                result.add(new int[]{cx, cz});
+            }
+        }
+        return result;
+    }
+}

--- a/addons/SkylliaIslandValue/src/main/resources/config/config.toml
+++ b/addons/SkylliaIslandValue/src/main/resources/config/config.toml
@@ -1,0 +1,10 @@
+[island-level]
+level-expression = "FLOOR(SQRT(score / 10))"
+min-level = 0
+timer-interval-seconds = 300
+timer-interval-seconds-top = 120
+
+[blocks]
+DIRT = 1
+GRASS_BLOCK = 2
+STONE = 3

--- a/addons/SkylliaIslandValue/src/main/resources/config/config.toml
+++ b/addons/SkylliaIslandValue/src/main/resources/config/config.toml
@@ -1,10 +1,21 @@
 [island-level]
+# Mathematical formula to calculate the level from the score.
+# Available variables: score, level, size
+# Available functions: FLOOR, SQRT, CEIL, ABS, POW, LOG, MIN, MAX, ...
 level-expression = "FLOOR(SQRT(score / 10))"
+
+# Minimum guaranteed level (no island can drop below this)
 min-level = 0
+
+# Interval (in seconds) between two automatic scans of online islands
 timer-interval-seconds = 300
+
+# Cache validity duration for the Top leaderboard (in seconds)
 timer-interval-seconds-top = 120
 
 [blocks]
+# Assign each block type a value (positive decimal number)
+# Use Bukkit names in UPPERCASE
 DIRT = 1
 GRASS_BLOCK = 2
 STONE = 3

--- a/addons/SkylliaIslandValue/src/main/resources/paper-plugin.yml
+++ b/addons/SkylliaIslandValue/src/main/resources/paper-plugin.yml
@@ -1,0 +1,17 @@
+name: SkylliaIslandLevel
+main: fr.euphyllia.skylliaislandlevel.SkylliaIslandLevel
+loader: fr.euphyllia.skylliaislandlevel.IslandLevelLoader
+version: ${version}
+api-version: 1.20.5
+folia-supported: true
+
+dependencies:
+  server:
+    Skyllia:
+      load: BEFORE
+      required: true
+      join-classpath: true
+    PlaceholderAPI:
+      join-classpath: true
+      load: BEFORE
+      required: false

--- a/api/src/main/java/fr/euphyllia/skyllia/api/utils/nms/WorldNMS.java
+++ b/api/src/main/java/fr/euphyllia/skyllia/api/utils/nms/WorldNMS.java
@@ -3,11 +3,11 @@ package fr.euphyllia.skyllia.api.utils.nms;
 import fr.euphyllia.skyllia.api.configuration.WorldConfig;
 import fr.euphyllia.skyllia.api.skyblock.model.Position;
 import fr.euphyllia.skyllia.api.world.WorldFeedback;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.World;
-import org.bukkit.WorldCreator;
+import org.bukkit.*;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
 
 /**
  * Provides methods for interacting with the Minecraft world using NMS (net.minecraft.server) classes.
@@ -35,6 +35,8 @@ public abstract class WorldNMS {
     public WorldFeedback.FeedbackWorld createWorld(WorldCreator creator, WorldConfig worldConfig) {
         return createWorld(creator);
     }
+
+    public abstract Map<Material, Integer> getCountAllBlocksInChunk(@NotNull World world, int chunkX, int chunkZ);
 
     /**
      * Resets a chunk at the specified position in the given world.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,6 +150,7 @@ modrinth {
             project(":addons:SkylliaChallenge").tasks.named<Jar>("shadowJar"),
             project(":addons:SkylliaChest").tasks.named<Jar>("shadowJar"),
             project(":addons:SkylliaAcidRain").tasks.named<Jar>("shadowJar"),
+            project(":addons:SkylliaIslandValue").tasks.named<Jar>("shadowJar"),
         )
     )
 
@@ -195,5 +196,6 @@ tasks.modrinth {
         ":addons:SkylliaChallenge:shadowJar",
         ":addons:SkylliaChest:shadowJar",
         ":addons:SkylliaAcidRain:shadowJar",
+        ":addons:SkylliaIslandValue:shadowJar"
     )
 }

--- a/nms/v1_20_R4/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_20_R4/WorldNMS.java
+++ b/nms/v1_20_R4/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_20_R4/WorldNMS.java
@@ -65,6 +65,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -299,6 +300,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
         Bukkit.getPluginManager().callEvent(new WorldLoadEvent(internal.getWorld()));
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(internal.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v1_21_R1/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R1/WorldNMS.java
+++ b/nms/v1_21_R1/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R1/WorldNMS.java
@@ -65,6 +65,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -295,6 +296,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
         Bukkit.getPluginManager().callEvent(new WorldLoadEvent(internal.getWorld()));
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(internal.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v1_21_R2/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R2/WorldNMS.java
+++ b/nms/v1_21_R2/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R2/WorldNMS.java
@@ -65,6 +65,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -287,6 +288,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
         Bukkit.getPluginManager().callEvent(new WorldLoadEvent(internal.getWorld()));
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(internal.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v1_21_R3/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R3/WorldNMS.java
+++ b/nms/v1_21_R3/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R3/WorldNMS.java
@@ -65,6 +65,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -288,6 +289,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
         Bukkit.getPluginManager().callEvent(new WorldLoadEvent(internal.getWorld()));
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(internal.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v1_21_R4/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R4/WorldNMS.java
+++ b/nms/v1_21_R4/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R4/WorldNMS.java
@@ -69,6 +69,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -318,6 +319,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
         FeatureHooks.tickEntityManager(serverLevel);
         new WorldLoadEvent(serverLevel.getWorld()).callEvent();
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(serverLevel.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v1_21_R5/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R5/WorldNMS.java
+++ b/nms/v1_21_R5/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R5/WorldNMS.java
@@ -66,6 +66,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -305,6 +306,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
         FeatureHooks.tickEntityManager(serverLevel);
         new WorldLoadEvent(serverLevel.getWorld()).callEvent();
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(serverLevel.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v1_21_R6/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R6/WorldNMS.java
+++ b/nms/v1_21_R6/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R6/WorldNMS.java
@@ -69,6 +69,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -291,6 +292,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
         FeatureHooks.tickEntityManager(serverLevel);
         new WorldLoadEvent(serverLevel.getWorld()).callEvent();
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(serverLevel.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v1_21_R7/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R7/WorldNMS.java
+++ b/nms/v1_21_R7/src/main/java/fr/euphyllia/skyllia/utils/nms/v1_21_R7/WorldNMS.java
@@ -66,6 +66,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
 
@@ -293,6 +294,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
         new WorldLoadEvent(serverLevel.getWorld()).callEvent();
 
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(serverLevel.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/nms/v26_1/src/main/java/fr/euphyllia/skyllia/utils/nms/v26_1/WorldNMS.java
+++ b/nms/v26_1/src/main/java/fr/euphyllia/skyllia/utils/nms/v26_1/WorldNMS.java
@@ -55,8 +55,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static net.minecraft.server.MinecraftServer.getServer;
 
@@ -294,6 +296,37 @@ public class WorldNMS extends fr.euphyllia.skyllia.api.utils.nms.WorldNMS {
         craftServer.getServer().prepareLevel(serverLevel);
 
         return WorldFeedback.Feedback.SUCCESS.toFeedbackWorld(serverLevel.getWorld());
+    }
+
+    @Override
+    public Map<Material, Integer> getCountAllBlocksInChunk(World world, int chunkX, int chunkZ) {
+        Map<Material, Integer> blockCounts = new java.util.EnumMap<>(Material.class);
+        net.minecraft.server.level.ServerLevel nms = ((CraftWorld) world).getHandle();
+
+        LevelChunk chunk = nms.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            chunk = nms.getChunkSource().getChunk(chunkX, chunkZ, true);
+        }
+        if (chunk == null) {
+            return blockCounts;
+        }
+
+        final LevelChunkSection[] sections = chunk.getSections();
+        if (sections == null || sections.length == 0) {
+            return blockCounts;
+        }
+
+        for (LevelChunkSection section : sections) {
+            if (section == null || section.hasOnlyAir()) continue;
+
+            section.states.count((state, count) -> {
+                if (state.isAir()) return;
+                Material mat = state.getBukkitMaterial();
+                blockCounts.merge(mat, count, Integer::sum);
+            });
+        }
+
+        return blockCounts;
     }
 
     @Override

--- a/plugin/src/main/resources/language/en_GB.toml
+++ b/plugin/src/main/resources/language/en_GB.toml
@@ -404,6 +404,22 @@ no-permission = "<red>You do not have permission to open the island chest.</red>
 inventory-title = "<gold>%island_name%'s Island Chest</gold>"
 open = "<green>You have opened the island chest.</green>"
 
+[addons.island-value]
+no-permissions = "<red>You do not have permission to use this command."
+player-only-command = "<red>This command can only be used by a player."
+not-on-island = "<red>You do not have an island."
+already-scanning = "<yellow>A scan is already in progress for your island."
+scan-started = "<green>Scanning your island..."
+scan-completed = "<green>Scan complete! Score: <white>%score%</white> | Level: <white>%level%</white>"
+scan-start-failed = "<red>Failed to start the scan."
+level-command-usage = "<yellow>Usage: /is islevel <scan|top|rank>"
+invalid-page = "<red>%input% is not a valid page number."
+top-header = "<gold>=== Island Leaderboard — Page %page%/%max_page% (%total% islands) ===</gold>"
+top-empty = "<red>No islands are ranked yet."
+top-line = "<yellow>#%rank%</yellow> <white>%owner%</white> <gray>-</gray> Lv. <aqua>%level%</aqua> <dark_gray>(%score% pts)</dark_gray>"
+rank-self = "<yellow>#%rank%</yellow> <white>%owner% (you)</white> <gray>-</gray> Lv. <aqua>%level%</aqua> <dark_gray>(%score% pts)</dark_gray>"
+rank-self-unranked = "<white>%owner% (you)</white> <gray>are not ranked yet.</gray>"
+
 [addons.acid-island]
 water-contact = "<red>⚠ Acidic water burns you!</red>"
 rain-contact = "<dark_aqua>☔ Acid rain is eating away at your skin!</dark_aqua>"

--- a/plugin/src/main/resources/language/en_US.toml
+++ b/plugin/src/main/resources/language/en_US.toml
@@ -405,6 +405,22 @@ no-permission = "<red>You do not have permission to open the island chest.</red>
 inventory-title = "<gold>%island_name%'s Island Chest</gold>"
 open = "<green>You have opened the island chest.</green>"
 
+[addons.island-value]
+no-permissions = "<red>You do not have permission to use this command."
+player-only-command = "<red>This command can only be used by a player."
+not-on-island = "<red>You do not have an island."
+already-scanning = "<yellow>A scan is already in progress for your island."
+scan-started = "<green>Scanning your island..."
+scan-completed = "<green>Scan complete! Score: <white>%score%</white> | Level: <white>%level%</white>"
+scan-start-failed = "<red>Failed to start the scan."
+level-command-usage = "<yellow>Usage: /is islevel <scan|top|rank>"
+invalid-page = "<red>%input% is not a valid page number."
+top-header = "<gold>=== Island Leaderboard — Page %page%/%max_page% (%total% islands) ===</gold>"
+top-empty = "<red>No islands are ranked yet."
+top-line = "<yellow>#%rank%</yellow> <white>%owner%</white> <gray>-</gray> Lv. <aqua>%level%</aqua> <dark_gray>(%score% pts)</dark_gray>"
+rank-self = "<yellow>#%rank%</yellow> <white>%owner% (you)</white> <gray>-</gray> Lv. <aqua>%level%</aqua> <dark_gray>(%score% pts)</dark_gray>"
+rank-self-unranked = "<white>%owner% (you)</white> <gray>are not ranked yet.</gray>"
+
 [addons.acid-island]
 water-contact = "<red>⚠ Acidic water burns you!</red>"
 rain-contact = "<dark_aqua>☔ Acid rain is eating away at your skin!</dark_aqua>"

--- a/plugin/src/main/resources/language/fr_FR.toml
+++ b/plugin/src/main/resources/language/fr_FR.toml
@@ -411,6 +411,22 @@ no-permission = "<red>Votre rang ne vous permet pas d'utiliser ce coffre."
 inventory-title = "<gold>=== Coffre de l'île de %island_name% ===</gold>"
 open = "<green>Vous avez ouvert le coffre de l'île.</green>"
 
+[addons.island-value]
+no-permissions = "<red>Vous n'avez pas la permission d'utiliser cette commande."
+player-only-command = "<red>Cette commande ne peut être utilisée que par un joueur."
+not-on-island = "<red>Vous n'avez pas d'île."
+already-scanning = "<yellow>Un scan est déjà en cours pour votre île."
+scan-started = "<green>Scan de votre île en cours..."
+scan-completed = "<green>Scan terminé ! Score : <white>%score%</white> | Niveau : <white>%level%</white>"
+scan-start-failed = "<red>Impossible de démarrer le scan."
+level-command-usage = "<yellow>Usage : /is islevel <scan|top|rank>"
+invalid-page = "<red>%input% n'est pas un numéro de page valide."
+top-header = "<gold>=== Classement des îles — Page %page%/%max_page% (%total% îles) ===</gold>"
+top-empty = "<red>Aucune île n'est encore classée."
+top-line = "<yellow>#%rank%</yellow> <white>%owner%</white> <gray>-</gray> Nv. <aqua>%level%</aqua> <dark_gray>(%score% pts)</dark_gray>"
+rank-self = "<yellow>#%rank%</yellow> <white>%owner% (vous)</white> <gray>-</gray> Nv. <aqua>%level%</aqua> <dark_gray>(%score% pts)</dark_gray>"
+rank-self-unranked = "<white>%owner% (vous)</white> <gray>n'êtes pas encore classé.</gray>"
+
 [addons.acid-island]
 water-contact = "<red>⚠ L'eau acide vous brûle !</red>"
 rain-contact = "<dark_aqua>☔ La pluie acide vous ronge la peau !</dark_aqua>"
@@ -983,3 +999,4 @@ description = "Contrôle l'apparition des Illusionnistes."
 [debug]
 permission-has = "%player% a la permission : %permission%"
 permission-missing = "%player% n'a pas la permission : %permission%"
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include("addons:SkylliaBank")
 include("addons:SkylliaChallenge")
 include("addons:SkylliaChest")
 include("addons:SkylliaAcidRain")
+include("addons:SkylliaIslandValue")
 // Hook
 include("hook:worldedit")
 include("hook:fastasyncworldedit")


### PR DESCRIPTION
## Description (FR)

Ajout du plugin addon **SkylliaIslandLevel** permettant de calculer un score et un niveau pour chaque île Skyllia en fonction des blocs qui la composent.

## Fonctionnalités ajoutées

- Scan automatique périodique des îles des joueurs en ligne
- Calcul d'un score pondéré par type de bloc (configurable via `config.toml`)
- Conversion du score en niveau via une formule mathématique personnalisable (EvalEx)
- Commandes `/island level scan`, `top` et `rank`
- Support **PlaceholderAPI** : `%islandlevel_level%`, `%islandlevel_score%`, `%islandlevel_rank%`, `%islandlevel_top_<N>_*%`
- Cache asynchrone pour les placeholders et le classement
- Support natif **Folia** via `RegionScheduler`
- Stockage des données dans le PersistentData de Skyllia (sans base externe)

## Notes

- Version bêta — des ajustements sont à prévoir
- Nécessite une version de Skyllia supportant `getCountAllBlocksInChunk`

---

## Description (EN)

Adds the **SkylliaIslandLevel** addon plugin, which calculates a score and a level for each Skyllia island based on the blocks it contains.

## Changes

- Periodic automatic scan of online players' islands
- Weighted block score calculation, fully configurable via `config.toml`
- Score-to-level conversion using a customizable math formula (EvalEx)
- Commands: `/island level scan`, `top`, `rank`
- **PlaceholderAPI** support: `%islandlevel_level%`, `%islandlevel_score%`, `%islandlevel_rank%`, `%islandlevel_top_<N>_*%`
- Async cache for placeholders and leaderboard
- Native **Folia** support via `RegionScheduler`
- Data stored in Skyllia's PersistentData (no external database)

## Notes

- Beta release — adjustments expected
- Requires a version of Skyllia that supports `getCountAllBlocksInChunk`