### PR TITLE
Addons: SkylliaBackup

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -11,6 +11,7 @@
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/addons" />
             <option value="$PROJECT_DIR$/addons/SkylliaAcidRain" />
+            <option value="$PROJECT_DIR$/addons/SkylliaBackup" />
             <option value="$PROJECT_DIR$/addons/SkylliaBank" />
             <option value="$PROJECT_DIR$/addons/SkylliaChallenge" />
             <option value="$PROJECT_DIR$/addons/SkylliaChat" />

--- a/addons/SkylliaBackup/build.gradle.kts
+++ b/addons/SkylliaBackup/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("java")
+}
+
+group = "fr.euphyllia.skylliabackup"
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
+
+    compileOnly(project(":api"))
+    compileOnly(project(":plugin"))
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+tasks {
+    compileJava {
+        options.encoding = "UTF-8"
+    }
+}

--- a/addons/SkylliaBackup/readme.md
+++ b/addons/SkylliaBackup/readme.md
@@ -1,0 +1,165 @@
+# SkylliaBackup
+
+**SkylliaBackup** is an addon for the [Skyllia](https://github.com/Euphyllia/Skyllia) skyblock plugin. It allows automatic and on-demand backups of skyblock islands: each backup packages the relevant Minecraft region files (`.mca`) into a ZIP archive, with optional rotation and HTTP upload support.
+
+---
+
+## Requirements
+
+| Dependency    | Version   |
+|---------------|-----------|
+| Paper / Folia | 1.20.6+   |
+| Java          | 21+       |
+| Skyllia       | Latest    |
+
+---
+
+## Features
+
+- Back up any island's region files into a structured **ZIP archive**
+- Players can trigger a backup of their own island via `/is backup`
+- Admins can back up a specific player's island or **all islands at once** via `/isadmin backup`
+- Configurable **cooldown** between player-triggered backups
+- Automatic **backup rotation** — keeps only the N most recent backups per island
+- Optional **HTTP upload** of backup ZIPs to an external endpoint (with Bearer token support)
+- **Folia compatible** — all async work runs on Folia's async scheduler
+- Config is registered in Skyllia's config registry and supports **hot-reload**
+
+---
+
+## How It Works
+
+### Backup Process
+
+When a backup is triggered (by a player or an admin), the following steps occur:
+
+1. The island's registered Skyllia worlds are retrieved.
+2. Region files (`.mca`) covering the island's footprint are collected from each world's `region/` folder.
+3. A ZIP archive is created with the following internal structure:
+   ```
+   <islandId>/
+     backup-info.txt          ← Island ID, timestamp, file count
+     <worldName>/region/r.X.Z.mca
+     ...
+   ```
+4. The ZIP is saved under `<backupFolder>/<islandId>/backup_<owner>_<trigger>_<timestamp>.zip`.
+5. Old backups beyond the configured maximum are **deleted** (oldest first).
+6. If an upload URL is configured, the ZIP is **uploaded asynchronously** via multipart HTTP POST.
+
+### Backup Rotation
+
+Old backups are automatically pruned when the number of ZIPs in an island's folder exceeds `max-per-island`. The oldest files (by last-modified date) are deleted first.
+
+### Upload
+
+If `upload.url` is set, each backup ZIP is uploaded to that endpoint as a `multipart/form-data` POST with two fields:
+
+| Field       | Content                          |
+|-------------|----------------------------------|
+| `island_id` | The island's UUID                |
+| `file`      | The ZIP file (`application/zip`) |
+
+An `Authorization: Bearer <token>` header is added when `upload.token` is set.
+
+---
+
+## Commands
+
+### Player Command
+
+```
+/is backup
+```
+
+Creates a backup of the player's own island. Subject to cooldown.
+
+| Permission            | Description                  |
+|-----------------------|------------------------------|
+| `skyllia.island.backup` | Allows using `/is backup`  |
+
+### Admin Command
+
+```
+/isadmin backup <player|all>
+```
+
+- `<player>` — backs up the specified player's island immediately.
+- `all` — backs up every active island on the server.
+
+| Permission                        | Description                      |
+|-----------------------------------|----------------------------------|
+| `skyllia.admins.commands.backup`  | Allows using `/isadmin backup`   |
+
+---
+
+## Configuration
+
+The config file is generated automatically at `plugins/SkylliaBackup/config.toml` on first run.
+
+```toml
+[backup]
+# Directory where backup ZIPs are stored (absolute or relative to server root)
+# Example for a NAS mount: "/mnt/nas/minecraft-backups"
+folder = "plugins/SkylliaBackup/backups"
+
+# Maximum number of backups kept per island (0 = unlimited)
+max-per-island = 5
+
+# Allow players to create a backup of their own island via /is backup
+allow-player-backup = true
+
+# Cooldown in seconds between two player-triggered backups (0 = disabled)
+# 3600 = 1 hour
+player-cooldown-seconds = 3600
+
+[upload]
+# HTTP endpoint to upload backup ZIPs to (leave empty to disable)
+# Example: "http://my-server:3000/upload"
+url = ""
+
+# Bearer token sent in the Authorization header (leave empty if none)
+token = ""
+```
+
+### Config Reference
+
+| Key                              | Type    | Default                           | Description                                            |
+|----------------------------------|---------|-----------------------------------|--------------------------------------------------------|
+| `backup.folder`                  | string  | `"plugins/SkylliaBackup/backups"` | Directory where ZIP archives are stored                |
+| `backup.max-per-island`          | int     | `5`                               | Max backups kept per island (`0` = unlimited)          |
+| `backup.allow-player-backup`     | boolean | `true`                            | Whether players can trigger their own backup           |
+| `backup.player-cooldown-seconds` | long    | `3600`                            | Cooldown in seconds between player backups (`0` = off) |
+| `upload.url`                     | string  | `""`                              | HTTP endpoint to upload ZIPs to (empty = disabled)     |
+| `upload.token`                   | string  | `""`                              | Bearer token for the upload endpoint                   |
+
+---
+
+## Installation
+
+1. Make sure **Skyllia** is installed and enabled.
+2. Drop the `SkylliaBackup.jar` into your `plugins/` folder.
+3. Start or reload the server — the config is generated automatically.
+4. Edit `plugins/SkylliaBackup/config.toml` to your liking.
+5. Use Skyllia's reload command to apply config changes without restarting.
+
+---
+
+## Language Keys
+
+The following keys must be present in your Skyllia language file:
+
+| Key                                | Description                                                        |
+|------------------------------------|--------------------------------------------------------------------|
+| `addons.backup.player.player-only` | Shown when a non-player runs `/is backup`                          |
+| `addons.backup.player.disabled`    | Shown when player backups are disabled                             |
+| `addons.backup.player.cooldown`    | Cooldown message (placeholders: `%minutes%`, `%seconds%`)          |
+| `addons.backup.player.started`     | Shown when the backup starts                                       |
+| `addons.backup.player.success`     | Shown on success (placeholder: `%file%`)                           |
+| `addons.backup.player.failed`      | Shown on failure                                                   |
+| `addons.backup.player.uploading`   | Shown when upload is in progress                                   |
+| `addons.backup.admin.usage`        | Usage hint for `/isadmin backup`                                   |
+| `addons.backup.admin.all-started`  | Shown when a full backup is starting                               |
+| `addons.backup.admin.all-done`     | Shown when full backup finishes (placeholder: `%count%`)           |
+| `addons.backup.admin.started`      | Shown when a single-island backup starts (placeholder: `%player%`) |
+| `addons.backup.admin.success`      | Shown on success (placeholders: `%player%`, `%file%`)              |
+| `addons.backup.admin.failed`       | Shown on failure (placeholder: `%player%`)                         |

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/SkylliaBackup.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/SkylliaBackup.java
@@ -2,6 +2,8 @@ package fr.euphyllia.skylliabackup;
 
 import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skylliabackup.commands.BackupCommand;
+import fr.euphyllia.skylliabackup.commands.admin.BackupAdminCommand;
+import fr.euphyllia.skylliabackup.configuration.BackupConfigLoader;
 import fr.euphyllia.skylliabackup.manager.BackupManager;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -11,25 +13,45 @@ import org.slf4j.LoggerFactory;
 public class SkylliaBackup extends JavaPlugin {
 
     private static final Logger log = LoggerFactory.getLogger(SkylliaBackup.class);
+    private static SkylliaBackup instance;
     private BackupManager backupManager;
+
+    public static SkylliaBackup getInstance() {
+        return instance;
+    }
 
     @Override
     public void onEnable() {
+        instance = this;
+
         if (getServer().getPluginManager().getPlugin("Skyllia") == null) {
             log.error("Skyllia is not installed! SkylliaBackup will stop.");
             getServer().getPluginManager().disablePlugin(this);
             return;
         }
 
-        this.backupManager = new BackupManager(this);
+        try {
+            BackupConfigLoader.init(getDataFolder());
+        } catch (Exception e) {
+            log.error("Failed to load SkylliaBackup config", e);
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        this.backupManager = new BackupManager(this, BackupConfigLoader.config);
 
         SkylliaAPI.registerCommands(new BackupCommand(this), "backup");
+        SkylliaAPI.registerAdminCommands(new BackupAdminCommand(this), "backup");
+
+        log.info("SkylliaBackup enabled.");
     }
 
     @Override
     public void onDisable() {
+        BackupConfigLoader.unregister();
         Bukkit.getAsyncScheduler().cancelTasks(this);
         Bukkit.getGlobalRegionScheduler().cancelTasks(this);
+        log.info("SkylliaBackup disabled.");
     }
 
     public BackupManager getBackupManager() {

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/SkylliaBackup.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/SkylliaBackup.java
@@ -1,0 +1,38 @@
+package fr.euphyllia.skylliabackup;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skylliabackup.commands.BackupCommand;
+import fr.euphyllia.skylliabackup.manager.BackupManager;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SkylliaBackup extends JavaPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(SkylliaBackup.class);
+    private BackupManager backupManager;
+
+    @Override
+    public void onEnable() {
+        if (getServer().getPluginManager().getPlugin("Skyllia") == null) {
+            log.error("Skyllia is not installed! SkylliaBackup will stop.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        this.backupManager = new BackupManager(this);
+
+        SkylliaAPI.registerCommands(new BackupCommand(this), "backup");
+    }
+
+    @Override
+    public void onDisable() {
+        Bukkit.getAsyncScheduler().cancelTasks(this);
+        Bukkit.getGlobalRegionScheduler().cancelTasks(this);
+    }
+
+    public BackupManager getBackupManager() {
+        return backupManager;
+    }
+}

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/commands/BackupCommand.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/commands/BackupCommand.java
@@ -1,0 +1,62 @@
+package fr.euphyllia.skylliabackup.commands;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skylliabackup.SkylliaBackup;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+import java.util.UUID;
+
+public class BackupCommand implements SubCommandInterface {
+
+    private static final Logger log = LoggerFactory.getLogger(BackupCommand.class);
+    private final SkylliaBackup plugin;
+
+    public BackupCommand(SkylliaBackup plugin) {
+        this.plugin = plugin;
+    }
+
+
+    @Override
+    public void onExecute(@NotNull Plugin plugin, @NotNull CommandSender sender, @NonNull @NotNull String[] args) {
+        if (!(sender instanceof Player player)) {
+            log.error("You are not a player");
+            return;
+        }
+
+        UUID playerId = player.getUniqueId();
+
+        Island island = SkylliaAPI.getIslandByPlayerId(playerId);
+        if (island == null) {
+            log.error("Not island");
+            return;
+        }
+
+        File result = this.plugin.getBackupManager().backupIsland(island, player.getName());
+        if (result != null) {
+            log.info("Backup created !");
+        } else {
+            log.error("ERROR");
+        }
+
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NonNull @NotNull String[] args) {
+        return List.of();
+    }
+
+    @Override
+    public String permission() {
+        return "skyllia.island.backup";
+    }
+}

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/commands/BackupCommand.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/commands/BackupCommand.java
@@ -3,51 +3,79 @@ package fr.euphyllia.skylliabackup.commands;
 import fr.euphyllia.skyllia.api.SkylliaAPI;
 import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
 import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
 import fr.euphyllia.skylliabackup.SkylliaBackup;
+import fr.euphyllia.skylliabackup.configuration.BackupConfigLoader;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class BackupCommand implements SubCommandInterface {
 
-    private static final Logger log = LoggerFactory.getLogger(BackupCommand.class);
     private final SkylliaBackup plugin;
 
     public BackupCommand(SkylliaBackup plugin) {
         this.plugin = plugin;
     }
 
-
     @Override
     public void onExecute(@NotNull Plugin plugin, @NotNull CommandSender sender, @NonNull @NotNull String[] args) {
         if (!(sender instanceof Player player)) {
-            log.error("You are not a player");
+            ConfigLoader.language.sendMessage(sender, "addons.backup.player.player-only");
+            return;
+        }
+
+        if (!player.hasPermission(permission())) {
+            ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
+            return;
+        }
+
+        if (!BackupConfigLoader.config.isAllowPlayerBackup()) {
+            ConfigLoader.language.sendMessage(player, "addons.backup.player.disabled");
             return;
         }
 
         UUID playerId = player.getUniqueId();
 
-        Island island = SkylliaAPI.getIslandByPlayerId(playerId);
-        if (island == null) {
-            log.error("Not island");
+        // Cooldown
+        long remaining = this.plugin.getBackupManager().getRemainingCooldown(playerId);
+        if (remaining > 0) {
+            long minutes = remaining / 60;
+            long seconds = remaining % 60;
+            ConfigLoader.language.sendMessage(player, "addons.backup.player.cooldown",
+                    Map.of("%minutes%", String.valueOf(minutes), "%seconds%", String.valueOf(seconds)));
             return;
         }
 
-        File result = this.plugin.getBackupManager().backupIsland(island, player.getName());
-        if (result != null) {
-            log.info("Backup created !");
-        } else {
-            log.error("ERROR");
+        Island island = SkylliaAPI.getIslandByPlayerId(playerId);
+        if (island == null) {
+            ConfigLoader.language.sendMessage(player, "island.player.no-island");
+            return;
         }
 
+        ConfigLoader.language.sendMessage(player, "addons.backup.player.started");
+
+        Bukkit.getAsyncScheduler().runNow(this.plugin, task -> {
+            File result = this.plugin.getBackupManager().backupIsland(island, player.getName());
+            if (result != null) {
+                this.plugin.getBackupManager().stampCooldown(playerId);
+                ConfigLoader.language.sendMessage(player, "addons.backup.player.success",
+                        Map.of("%file%", result.getName()));
+                if (BackupConfigLoader.config.isUploadEnabled()) {
+                    ConfigLoader.language.sendMessage(player, "addons.backup.player.uploading");
+                }
+            } else {
+                ConfigLoader.language.sendMessage(player, "addons.backup.player.failed");
+            }
+        });
     }
 
     @Override

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/commands/admin/BackupAdminCommand.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/commands/admin/BackupAdminCommand.java
@@ -1,0 +1,110 @@
+package fr.euphyllia.skylliabackup.commands.admin;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.commands.SubCommandInterface;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.configuration.ConfigLoader;
+import fr.euphyllia.skylliabackup.SkylliaBackup;
+import fr.euphyllia.skylliabackup.configuration.BackupConfigLoader;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class BackupAdminCommand implements SubCommandInterface {
+
+    private final SkylliaBackup plugin;
+
+    public BackupAdminCommand(SkylliaBackup plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void onExecute(@NotNull Plugin plugin, @NotNull CommandSender sender, @NonNull @NotNull String[] args) {
+        if (!sender.hasPermission(permission())) {
+            ConfigLoader.language.sendMessage(sender, "island.player.permission-denied");
+            return;
+        }
+
+        if (args.length < 1) {
+            ConfigLoader.language.sendMessage(sender, "addons.backup.admin.usage");
+            return;
+        }
+
+        String target = args[0].trim();
+
+        if (target.equalsIgnoreCase("all")) {
+            ConfigLoader.language.sendMessage(sender, "addons.backup.admin.all-started");
+
+            Bukkit.getAsyncScheduler().runNow(this.plugin, task -> {
+                int count = this.plugin.getBackupManager().backupAllIslands();
+                ConfigLoader.language.sendMessage(sender, "addons.backup.admin.all-done",
+                        Map.of("%count%", String.valueOf(count)));
+            });
+
+        } else {
+            UUID targetId = Bukkit.getPlayerUniqueId(target);
+            if (targetId == null) {
+                targetId = Bukkit.getOfflinePlayer(target).getUniqueId();
+            }
+            if (targetId == null) {
+                ConfigLoader.language.sendMessage(sender, "island.admin.player-not-found",
+                        Map.of("%player%", target));
+                return;
+            }
+
+            final UUID finalTargetId = targetId;
+            Island island = SkylliaAPI.getIslandByPlayerId(finalTargetId);
+            if (island == null) {
+                ConfigLoader.language.sendMessage(sender, "island.player.no-island");
+                return;
+            }
+
+            ConfigLoader.language.sendMessage(sender, "addons.backup.admin.started",
+                    Map.of("%player%", target));
+
+            Bukkit.getAsyncScheduler().runNow(this.plugin, task -> {
+                File result = this.plugin.getBackupManager().backupIsland(island, "admin-" + sender.getName());
+                if (result != null) {
+                    ConfigLoader.language.sendMessage(sender, "addons.backup.admin.success",
+                            Map.of("%player%", target, "%file%", result.getName()));
+                    if (BackupConfigLoader.config.isUploadEnabled()) {
+                        ConfigLoader.language.sendMessage(sender, "addons.backup.player.uploading");
+                    }
+                } else {
+                    ConfigLoader.language.sendMessage(sender, "addons.backup.admin.failed",
+                            Map.of("%player%", target));
+                }
+            });
+        }
+    }
+
+    @Override
+    public @NotNull List<String> onTabComplete(@NotNull Plugin plugin, @NotNull CommandSender sender, @NonNull @NotNull String[] args) {
+        if (!sender.hasPermission(permission())) return List.of();
+        if (args.length == 1) {
+            String partial = args[0].toLowerCase();
+            List<String> suggestions = new ArrayList<>();
+            suggestions.add("all");
+            Bukkit.getOnlinePlayers().stream()
+                    .map(p -> p.getName())
+                    .filter(name -> name.toLowerCase().startsWith(partial))
+                    .sorted()
+                    .forEach(suggestions::add);
+            return suggestions;
+        }
+        return List.of();
+    }
+
+    @Override
+    public String permission() {
+        return "skyllia.admins.commands.backup";
+    }
+}

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/configuration/BackupConfigLoader.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/configuration/BackupConfigLoader.java
@@ -1,0 +1,32 @@
+package fr.euphyllia.skylliabackup.configuration;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+
+import java.io.File;
+
+public class BackupConfigLoader {
+    public static BackupConfigManager config;
+
+    public static void init(File dataFolder) throws Exception {
+        //noinspection ResultOfMethodCallIgnored
+        dataFolder.mkdirs();
+
+        config = new BackupConfigManager(loadFile(new File(dataFolder, "config.toml")));
+        config.loadConfig();
+
+        SkylliaAPI.getConfigRegistry().registerConfig(config);
+    }
+
+    public static void unregister() {
+        if (config != null) {
+            SkylliaAPI.getConfigRegistry().unregisterConfig(config);
+        }
+    }
+
+    private static CommentedFileConfig loadFile(File file) {
+        CommentedFileConfig cfg = CommentedFileConfig.builder(file).sync().autosave().build();
+        cfg.load();
+        return cfg;
+    }
+}

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/configuration/BackupConfigManager.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/configuration/BackupConfigManager.java
@@ -1,0 +1,110 @@
+package fr.euphyllia.skylliabackup.configuration;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.electronwill.nightconfig.core.io.IndentStyle;
+import com.electronwill.nightconfig.core.io.WritingMode;
+import com.electronwill.nightconfig.toml.TomlWriter;
+import fr.euphyllia.skyllia.api.configuration.IConfigurationProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackupConfigManager implements IConfigurationProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(BackupConfigManager.class);
+
+    private final CommentedFileConfig config;
+    private boolean changed = false;
+
+    private String backupFolder;
+    private int maxBackupsPerIsland;
+    private boolean allowPlayerBackup;
+    private long playerCooldownSeconds;
+
+    private String uploadUrl;
+    private String uploadToken;
+
+    public BackupConfigManager(CommentedFileConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void loadConfig() {
+        changed = false;
+
+        // [backup]
+        this.backupFolder = getOrSetDefault("backup.folder", "plugins/SkylliaBackup/backups", String.class);
+        this.maxBackupsPerIsland = getOrSetDefault("backup.max-per-island", 5, Integer.class);
+        this.allowPlayerBackup = getOrSetDefault("backup.allow-player-backup", true, Boolean.class);
+        this.playerCooldownSeconds = getOrSetDefault("backup.player-cooldown-seconds", 3600L, Long.class);
+
+        // [upload]
+        this.uploadUrl = getOrSetDefault("upload.url", "", String.class);
+        this.uploadToken = getOrSetDefault("upload.token", "", String.class);
+
+        if (changed) {
+            TomlWriter tomlWriter = new TomlWriter();
+            tomlWriter.setIndent(IndentStyle.NONE);
+            tomlWriter.write(config, config.getFile(), WritingMode.REPLACE);
+        }
+
+        log.info("(Re)Loaded config SkylliaBackup");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getOrSetDefault(String path, T defaultValue, Class<T> expectedClass) {
+        Object value = config.get(path);
+        if (value == null) {
+            config.set(path, defaultValue);
+            changed = true;
+            return defaultValue;
+        }
+        if (expectedClass.isInstance(value)) return (T) value;
+        return switch (value) {
+            case Integer i when expectedClass == Long.class -> (T) Long.valueOf(i);
+            case Double d when expectedClass == Float.class -> (T) Float.valueOf(d.floatValue());
+            case Integer i when expectedClass == Double.class -> (T) Double.valueOf(i);
+            default -> throw new IllegalStateException(
+                    "Cannot convert value at '" + path + "' from "
+                            + value.getClass().getSimpleName() + " to " + expectedClass.getSimpleName());
+        };
+    }
+
+    @Override
+    public void reloadFromDisk() {
+        config.load();
+    }
+
+    @Override
+    public boolean canReloadFromDisk() {
+        return true;
+    }
+
+    public String getBackupFolder() {
+        return backupFolder;
+    }
+
+    public int getMaxBackupsPerIsland() {
+        return maxBackupsPerIsland;
+    }
+
+    public boolean isAllowPlayerBackup() {
+        return allowPlayerBackup;
+    }
+
+    public long getPlayerCooldownSeconds() {
+        return playerCooldownSeconds;
+    }
+
+    public String getUploadUrl() {
+        return uploadUrl;
+    }
+
+    public String getUploadToken() {
+        return uploadToken;
+    }
+
+    public boolean isUploadEnabled() {
+        return uploadUrl != null && !uploadUrl.isBlank();
+    }
+}

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/manager/BackupManager.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/manager/BackupManager.java
@@ -8,19 +8,17 @@ import fr.euphyllia.skyllia.api.skyblock.model.Position;
 import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
 import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
 import fr.euphyllia.skylliabackup.SkylliaBackup;
+import fr.euphyllia.skylliabackup.configuration.BackupConfigManager;
 import org.bukkit.Bukkit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -28,14 +26,28 @@ public class BackupManager {
 
     private static final Logger log = LoggerFactory.getLogger(BackupManager.class);
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
-    private final SkylliaBackup plugin;
-    private final File serverRoot;
 
-    public BackupManager(SkylliaBackup plugin) {
+    private final SkylliaBackup plugin;
+    private final BackupConfigManager config;
+    private final Map<UUID, Long> playerCooldowns = new HashMap<>();
+
+    public BackupManager(SkylliaBackup plugin, BackupConfigManager config) {
         this.plugin = plugin;
-        this.serverRoot = Bukkit.getWorldContainer();
+        this.config = config;
     }
 
+    public long getRemainingCooldown(UUID playerId) {
+        long cooldown = config.getPlayerCooldownSeconds();
+        if (cooldown <= 0) return 0;
+        Long last = playerCooldowns.get(playerId);
+        if (last == null) return 0;
+        long elapsed = (System.currentTimeMillis() / 1000L) - last;
+        return Math.max(0, cooldown - elapsed);
+    }
+
+    public void stampCooldown(UUID playerId) {
+        playerCooldowns.put(playerId, System.currentTimeMillis() / 1000L);
+    }
 
     public File backupIsland(Island island, String trigger) {
         UUID islandId = island.getId();
@@ -51,11 +63,8 @@ public class BackupManager {
         for (WorldConfig worldCfg : worlds) {
             String worldName = worldCfg.getWorldName();
             List<Position> regions = RegionHelper.getRegionsWithinBlockRange(pos, (int) island.getSize());
-            log.info("Island pos: ({}, {}), size: {}, regions found: {}",
-                    pos.x(), pos.z(), island.getSize(), regions.size());
             for (Position region : regions) {
                 File mca = getRegionFile(worldName, region);
-                log.info("Checking: {} | exists: {}", mca.getAbsolutePath(), mca.exists());
                 if (mca != null && mca.exists()) {
                     regionFiles.add(mca);
                 }
@@ -63,11 +72,10 @@ public class BackupManager {
         }
 
         if (regionFiles.isEmpty()) {
-            log.error("No region found"); // Devrait jamais arrivé
+            log.warn("No region files found for island {}", islandId);
             return null;
         }
 
-        String timestamp = DATE_FMT.format(LocalDateTime.now());
         String ownerName = islandId.toString().substring(0, 8);
         for (Players p : island.getMembers()) {
             if (p.getRoleType() == RoleType.OWNER) {
@@ -76,9 +84,11 @@ public class BackupManager {
             }
         }
 
-        File islandDir = new File(plugin.getDataFolder(), "/test/" + islandId);
+        File backupRoot = new File(config.getBackupFolder());
+        File islandDir = new File(backupRoot, islandId.toString());
         islandDir.mkdirs();
 
+        String timestamp = DATE_FMT.format(LocalDateTime.now());
         String zipName = String.format("backup_%s_%s_%s.zip", ownerName, trigger, timestamp);
         File zipFile = new File(islandDir, zipName);
 
@@ -89,8 +99,27 @@ public class BackupManager {
             return null;
         }
 
+        rotateBackups(islandDir);
+
+        if (config.isUploadEnabled()) {
+            final UUID finalIslandId = islandId;
+            Bukkit.getAsyncScheduler().runNow(plugin, task -> uploadBackup(zipFile, finalIslandId));
+        }
+
         log.info("Backup created: {}", zipFile.getAbsolutePath());
         return zipFile;
+    }
+
+    public int backupAllIslands() {
+        List<Island> islands = SkylliaAPI.getAllIslandsValid();
+        if (islands == null || islands.isEmpty()) return 0;
+        int count = 0;
+        for (Island island : islands) {
+            if (!island.isDisable()) {
+                if (backupIsland(island, "admin-all") != null) count++;
+            }
+        }
+        return count;
     }
 
     private File getRegionFile(String worldName, Position region) {
@@ -107,22 +136,19 @@ public class BackupManager {
         try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
             ZipEntry meta = new ZipEntry(islandId + "/backup-info.txt");
             zos.putNextEntry(meta);
-            String info = "Island ID: " + islandId + "\n" +
-                    "Created at: " + LocalDateTime.now() + "\n" +
-                    "Region files: " + regionFiles.size() + "\n";
+            String info = "Island ID: " + islandId + "\nCreated at: " + LocalDateTime.now() + "\nRegion files: " + regionFiles.size() + "\n";
             zos.write(info.getBytes());
             zos.closeEntry();
 
             for (File regionFile : regionFiles) {
-                String relativePath = islandId + "/" + relativize(serverRoot, regionFile);
+                // Structure dans le ZIP : <islandId>/<worldName>/region/r.X.Z.mca
+                String relativePath = islandId + "/" + relativize(Bukkit.getWorldContainer(), regionFile);
                 ZipEntry entry = new ZipEntry(relativePath.replace(File.separatorChar, '/'));
                 zos.putNextEntry(entry);
                 try (FileInputStream fis = new FileInputStream(regionFile)) {
                     byte[] buf = new byte[8192];
                     int len;
-                    while ((len = fis.read(buf)) > 0) {
-                        zos.write(buf, 0, len);
-                    }
+                    while ((len = fis.read(buf)) > 0) zos.write(buf, 0, len);
                 }
                 zos.closeEntry();
             }
@@ -133,9 +159,60 @@ public class BackupManager {
         return base.toURI().relativize(target.toURI()).getPath();
     }
 
-    private void uploadBackup(File zipFile, UUID islandId) {
-        // Todo
+    private void rotateBackups(File islandDir) {
+        int max = config.getMaxBackupsPerIsland();
+        if (max <= 0) return;
+        File[] zips = islandDir.listFiles((dir, name) -> name.endsWith(".zip"));
+        if (zips == null || zips.length <= max) return;
+        Arrays.sort(zips, Comparator.comparingLong(File::lastModified));
+        int toDelete = zips.length - max;
+        for (int i = 0; i < toDelete; i++) {
+            if (zips[i].delete()) log.debug("Rotated old backup: {}", zips[i].getName());
+        }
     }
 
+    private void uploadBackup(File zipFile, UUID islandId) {
+        String boundary = "----SkylliaBackup" + System.currentTimeMillis();
+        try {
+            URL url = new URL(config.getUploadUrl());
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setDoOutput(true);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+            conn.setRequestProperty("User-Agent", "SkylliaBackup/" + plugin.getPluginMeta().getVersion());
+            if (!config.getUploadToken().isBlank()) {
+                conn.setRequestProperty("Authorization", "Bearer " + config.getUploadToken());
+            }
 
+            try (OutputStream out = conn.getOutputStream()) {
+                writeField(out, boundary, "island_id", islandId.toString());
+                writeFilePart(out, boundary, "file", zipFile);
+                out.write(("\r\n--" + boundary + "--\r\n").getBytes());
+            }
+
+            int status = conn.getResponseCode();
+            if (status == 200 || status == 201) {
+                log.info("Backup uploaded for island {}: HTTP {}", islandId, status);
+            } else {
+                log.warn("Upload returned HTTP {} for island {}", status, islandId);
+            }
+            conn.disconnect();
+        } catch (Exception e) {
+            log.error("Failed to upload backup for island {}", islandId, e);
+        }
+    }
+
+    private void writeField(OutputStream out, String boundary, String name, String value) throws IOException {
+        out.write(("--" + boundary + "\r\nContent-Disposition: form-data; name=\"" + name + "\"\r\n\r\n" + value + "\r\n").getBytes());
+    }
+
+    private void writeFilePart(OutputStream out, String boundary, String fieldName, File file) throws IOException {
+        out.write(("--" + boundary + "\r\nContent-Disposition: form-data; name=\"" + fieldName + "\"; filename=\"" + file.getName() + "\"\r\nContent-Type: application/zip\r\n\r\n").getBytes());
+        try (FileInputStream fis = new FileInputStream(file)) {
+            byte[] buf = new byte[8192];
+            int len;
+            while ((len = fis.read(buf)) > 0) out.write(buf, 0, len);
+        }
+        out.write("\r\n".getBytes());
+    }
 }

--- a/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/manager/BackupManager.java
+++ b/addons/SkylliaBackup/src/main/java/fr/euphyllia/skylliabackup/manager/BackupManager.java
@@ -1,0 +1,141 @@
+package fr.euphyllia.skylliabackup.manager;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.configuration.WorldConfig;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.api.skyblock.Players;
+import fr.euphyllia.skyllia.api.skyblock.model.Position;
+import fr.euphyllia.skyllia.api.skyblock.model.RoleType;
+import fr.euphyllia.skyllia.api.utils.helper.RegionHelper;
+import fr.euphyllia.skylliabackup.SkylliaBackup;
+import org.bukkit.Bukkit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class BackupManager {
+
+    private static final Logger log = LoggerFactory.getLogger(BackupManager.class);
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
+    private final SkylliaBackup plugin;
+    private final File serverRoot;
+
+    public BackupManager(SkylliaBackup plugin) {
+        this.plugin = plugin;
+        this.serverRoot = Bukkit.getWorldContainer();
+    }
+
+
+    public File backupIsland(Island island, String trigger) {
+        UUID islandId = island.getId();
+        Position pos = island.getPosition();
+
+        List<WorldConfig> worlds = SkylliaAPI.getRegisteredWorlds();
+        if (worlds == null || worlds.isEmpty()) {
+            log.warn("No worlds registered in Skyllia — cannot backup island {}", islandId);
+            return null;
+        }
+
+        List<File> regionFiles = new ArrayList<>();
+        for (WorldConfig worldCfg : worlds) {
+            String worldName = worldCfg.getWorldName();
+            List<Position> regions = RegionHelper.getRegionsWithinBlockRange(pos, (int) island.getSize());
+            log.info("Island pos: ({}, {}), size: {}, regions found: {}",
+                    pos.x(), pos.z(), island.getSize(), regions.size());
+            for (Position region : regions) {
+                File mca = getRegionFile(worldName, region);
+                log.info("Checking: {} | exists: {}", mca.getAbsolutePath(), mca.exists());
+                if (mca != null && mca.exists()) {
+                    regionFiles.add(mca);
+                }
+            }
+        }
+
+        if (regionFiles.isEmpty()) {
+            log.error("No region found"); // Devrait jamais arrivé
+            return null;
+        }
+
+        String timestamp = DATE_FMT.format(LocalDateTime.now());
+        String ownerName = islandId.toString().substring(0, 8);
+        for (Players p : island.getMembers()) {
+            if (p.getRoleType() == RoleType.OWNER) {
+                ownerName = p.getLastKnowName();
+                break;
+            }
+        }
+
+        File islandDir = new File(plugin.getDataFolder(), "/test/" + islandId);
+        islandDir.mkdirs();
+
+        String zipName = String.format("backup_%s_%s_%s.zip", ownerName, trigger, timestamp);
+        File zipFile = new File(islandDir, zipName);
+
+        try {
+            createZip(zipFile, regionFiles, islandId.toString());
+        } catch (IOException e) {
+            log.error("Failed to create backup ZIP for island {}", islandId, e);
+            return null;
+        }
+
+        log.info("Backup created: {}", zipFile.getAbsolutePath());
+        return zipFile;
+    }
+
+    private File getRegionFile(String worldName, Position region) {
+        org.bukkit.World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            log.warn("World '{}' is not loaded, skipping", worldName);
+            return null;
+        }
+        File regionDir = new File(world.getWorldFolder(), "region");
+        return new File(regionDir, "r." + region.x() + "." + region.z() + ".mca");
+    }
+
+    private void createZip(File zipFile, List<File> regionFiles, String islandId) throws IOException {
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            ZipEntry meta = new ZipEntry(islandId + "/backup-info.txt");
+            zos.putNextEntry(meta);
+            String info = "Island ID: " + islandId + "\n" +
+                    "Created at: " + LocalDateTime.now() + "\n" +
+                    "Region files: " + regionFiles.size() + "\n";
+            zos.write(info.getBytes());
+            zos.closeEntry();
+
+            for (File regionFile : regionFiles) {
+                String relativePath = islandId + "/" + relativize(serverRoot, regionFile);
+                ZipEntry entry = new ZipEntry(relativePath.replace(File.separatorChar, '/'));
+                zos.putNextEntry(entry);
+                try (FileInputStream fis = new FileInputStream(regionFile)) {
+                    byte[] buf = new byte[8192];
+                    int len;
+                    while ((len = fis.read(buf)) > 0) {
+                        zos.write(buf, 0, len);
+                    }
+                }
+                zos.closeEntry();
+            }
+        }
+    }
+
+    private String relativize(File base, File target) {
+        return base.toURI().relativize(target.toURI()).getPath();
+    }
+
+    private void uploadBackup(File zipFile, UUID islandId) {
+        // Todo
+    }
+
+
+}

--- a/addons/SkylliaBackup/src/main/resources/config.toml
+++ b/addons/SkylliaBackup/src/main/resources/config.toml
@@ -1,0 +1,22 @@
+[backup]
+# Directory where backup ZIPs are stored (absolute path or relative to the server root)
+# Example for a NAS mount: "/mnt/nas/minecraft-backups"
+folder = "plugins/SkylliaBackup/backups"
+
+# Maximum number of backups kept per island (0 = unlimited)
+max-per-island = 5
+
+# Allow players to create a backup of their own island via /is backup
+allow-player-backup = true
+
+# Cooldown in seconds between two player-triggered backups (0 = disabled)
+# 3600 = 1 hour
+player-cooldown-seconds = 3600
+
+[upload]
+# HTTP endpoint to upload backup ZIPs to (leave empty to disable)
+# Example: "http://my-server:3000/upload"
+url = ""
+
+# Bearer token sent in the Authorization header (leave empty if none)
+token = ""

--- a/addons/SkylliaBackup/src/main/resources/paper-plugin.yml
+++ b/addons/SkylliaBackup/src/main/resources/paper-plugin.yml
@@ -1,0 +1,13 @@
+name: SkylliaBackup
+version: ${version}
+main: fr.euphyllia.skylliabackup.SkylliaBackup
+api-version: 1.20.6
+folia-supported: true
+description: "Island backup addon for Skyllia — creates .mca ZIPs and optionally uploads them."
+
+dependencies:
+  server:
+    Skyllia:
+      load: BEFORE
+      required: true
+      join-classpath: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,6 +155,7 @@ modrinth {
             project(":addons:SkylliaChest").tasks.named<Jar>("shadowJar"),
             project(":addons:SkylliaAcidRain").tasks.named<Jar>("shadowJar"),
             project(":addons:SkylliaIslandValue").tasks.named<Jar>("shadowJar"),
+            project(":addons:SkylliaBackup").tasks.named<Jar>("shadowJar"),
         )
     )
 
@@ -200,6 +201,7 @@ tasks.modrinth {
         ":addons:SkylliaChallenge:shadowJar",
         ":addons:SkylliaChest:shadowJar",
         ":addons:SkylliaAcidRain:shadowJar",
-        ":addons:SkylliaIslandValue:shadowJar"
+        ":addons:SkylliaIslandValue:shadowJar",
+        ":addons:SkylliaBackup:shadowJar"
     )
 }

--- a/plugin/src/main/resources/language/en_GB.toml
+++ b/plugin/src/main/resources/language/en_GB.toml
@@ -1000,3 +1000,21 @@ description = "Controls Illusioner spawning."
 [debug]
 permission-has = "%player% HAVE %permission% permission"
 permission-missing = "%player% DOESN'T HAVE %permission% permission"
+
+[addons.backup.player]
+player-only = "<red>This command can only be used by a player."
+disabled = "<red>Player backups are disabled on this server."
+cooldown = "<red>Please wait <yellow>%minutes%m %seconds%s</yellow> before requesting another backup."
+started = "<green>Starting backup of your island, please wait..."
+success = "<green>Backup created: <white>%file%"
+uploading = "<gray>Uploading backup to remote server..."
+failed = "<red>Backup failed. Please contact an administrator."
+no-permission = "<red>You do not have permission to backup your island."
+
+[addons.backup.admin]
+usage = "<yellow>Usage: /isadmin backup <player|all>"
+started = "<green>Starting backup for <white>%player%</white>'s island..."
+success = "<green>Backup created for <white>%player%</white>: <white>%file%"
+failed = "<red>Backup failed for <white>%player%</white>'s island."
+all-started = "<green>Starting backup of ALL islands, this may take a while..."
+all-done = "<green>Done: <white>%count%</white> islands backed up."

--- a/plugin/src/main/resources/language/en_US.toml
+++ b/plugin/src/main/resources/language/en_US.toml
@@ -1001,3 +1001,21 @@ description = "Controls Illusioner spawning."
 [debug]
 permission-has = "%player% HAVE %permission% permission"
 permission-missing = "%player% DOESN'T HAVE %permission% permission"
+
+[addons.backup.player]
+player-only = "<red>This command can only be used by a player."
+disabled = "<red>Player backups are disabled on this server."
+cooldown = "<red>Please wait <yellow>%minutes%m %seconds%s</yellow> before requesting another backup."
+started = "<green>Starting backup of your island, please wait..."
+success = "<green>Backup created: <white>%file%"
+uploading = "<gray>Uploading backup to remote server..."
+failed = "<red>Backup failed. Please contact an administrator."
+no-permission = "<red>You do not have permission to backup your island."
+
+[addons.backup.admin]
+usage = "<yellow>Usage: /isadmin backup <player|all>"
+started = "<green>Starting backup for <white>%player%</white>'s island..."
+success = "<green>Backup created for <white>%player%</white>: <white>%file%"
+failed = "<red>Backup failed for <white>%player%</white>'s island."
+all-started = "<green>Starting backup of ALL islands, this may take a while..."
+all-done = "<green>Done: <white>%count%</white> islands backed up."

--- a/plugin/src/main/resources/language/fr_FR.toml
+++ b/plugin/src/main/resources/language/fr_FR.toml
@@ -1008,3 +1008,20 @@ description = "Contrôle l'apparition des Illusionnistes."
 permission-has = "%player% a la permission : %permission%"
 permission-missing = "%player% n'a pas la permission : %permission%"
 
+[addons.backup.player]
+player-only = "<red>Cette commande ne peut être utilisée que par un joueur."
+disabled = "<red>Les backups joueurs sont désactivés sur ce serveur."
+cooldown = "<red>Veuillez attendre <yellow>%minutes%m %seconds%s</yellow> avant de demander un nouveau backup."
+started = "<green>Backup de votre île en cours, veuillez patienter..."
+success = "<green>Backup créé : <white>%file%"
+uploading = "<gray>Envoi du backup vers le serveur distant..."
+failed = "<red>Le backup a échoué. Veuillez contacter un administrateur."
+no-permission = "<red>Vous n'avez pas la permission de faire un backup de votre île."
+
+[addons.backup.admin]
+usage = "<yellow>Usage : /isadmin backup <joueur|all>"
+started = "<green>Backup de l'île de <white>%player%</white> en cours..."
+success = "<green>Backup créé pour <white>%player%</white> : <white>%file%"
+failed = "<red>Le backup de l'île de <white>%player%</white> a échoué."
+all-started = "<green>Backup de TOUTES les îles en cours, cela peut prendre du temps..."
+all-done = "<green>Terminé : <white>%count%</white> îles sauvegardées."

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include("addons:SkylliaChallenge")
 include("addons:SkylliaChest")
 include("addons:SkylliaAcidRain")
 include("addons:SkylliaIslandValue")
+include("addons:SkylliaBackup")
 // Hook
 include("hook:worldedit")
 include("hook:fastasyncworldedit")


### PR DESCRIPTION
The purpose of this addon is to easily create backups of islands. These backups could also be retrieved if desired to preserve player builds or other data.