### PR TITLE
Fix portal loop when teleporting into portal blocks

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/utils/WorldUtils.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/utils/WorldUtils.java
@@ -81,7 +81,8 @@ public final class WorldUtils {
         return switch (block.getType()) {
             case LAVA, FIRE, SOUL_FIRE, MAGMA_BLOCK,
                  SWEET_BERRY_BUSH, WITHER_ROSE,
-                 CACTUS, POWDER_SNOW -> true;
+                 CACTUS, POWDER_SNOW,
+                 NETHER_PORTAL, END_PORTAL, END_GATEWAY -> true;
             default -> false;
         };
     }


### PR DESCRIPTION
Related to #141.

This PR fixes a portal loop edge case after the portal teleport changes from #141.

When a player travels through an End portal between Skyblock worlds, the destination location can sometimes contain an `END_PORTAL` block at the same coordinates.

In that case, the player is teleported directly inside the portal block, which immediately triggers another portal teleport and creates a loop between worlds.

Tested on:
- Skyllia 3.0-113
- Folia 26.1.2

Permissions granted:
- `skyllia.use.portal.nether`
- `skyllia.use.portal.end`

Example flow:

- `sky-overworld` End portal -> `sky-end`
- Destination contains `END_PORTAL`
- Player lands inside the portal
- Portal event triggers again
- Player is sent back
- Loop repeats

Fix:
This marks portal blocks as unsafe destination blocks in `WorldUtils.isDangerous()`:

- `NETHER_PORTAL`
- `END_PORTAL`
- `END_GATEWAY`

This prevents `findSafeLocation()` from treating portal blocks as valid safe teleport destinations.

Video:

https://github.com/user-attachments/assets/165b0da2-6e25-4899-acb1-9d5f7b7c0fb5

