### PR TITLE
Handle unloaded worlds in force remove

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/ForceDeleteSubCommands.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/ForceDeleteSubCommands.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -89,8 +90,23 @@ public class ForceDeleteSubCommands implements SubCommandInterface {
                 } else {
                     worldsToDelete.forEach(entry -> {
                         String name = entry.getKey();
+                        World world = Bukkit.getWorld(name);
+                        if (world == null) {
+                            failed.set(true);
+                            logger.log(Level.FATAL, "Failed to delete island {} in world {}: world not loaded", island.getId(), name);
+                            if (worldsLeft.decrementAndGet() == 0) {
+                                boolean value = skyblockManager.setLockedIsland(island, true);
+                                if (value) {
+                                    ConfigLoader.language.sendMessage(sender, "island.generic.unexpected-error");
+                                } else {
+                                    logger.error("Failed to update lock state for island {} after deletion.", island.getId());
+                                }
+                            }
+                            return;
+                        }
+
                         Skyllia.getInstance().getInterneAPI().getWorldModifier()
-                                .deleteIsland(island, Bukkit.getWorld(name), ConfigLoader.general.getIslandSettings().regionDistance(), (success) -> {
+                                .deleteIsland(island, world, ConfigLoader.general.getIslandSettings().regionDistance(), (success) -> {
                                     if (!success) failed.set(true);
                                     if (worldsLeft.decrementAndGet() == 0) {
                                         boolean value = skyblockManager.setLockedIsland(island, failed.get());


### PR DESCRIPTION
The regular island remove command already checks if the world is loaded before deleting island chunks.

The force remove command was passing `Bukkit.getWorld(name)` directly to `deleteIsland`. If a configured skyblock world is not loaded, that can pass a null world into the chunk removal flow and leave the deletion callback unfinished.

I fixed it by checking the world first. If the world is missing, the remove operation is marked as failed, the island stays locked, and the missing world name is logged.

I only checked this code path, no live server test for this one.