### PR TITLE
Fix default island schematic keys and default creation fallback

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/Skyllia.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/Skyllia.java
@@ -114,7 +114,9 @@ public class Skyllia extends JavaPlugin {
     @Override
     public void onDisable() {
         context.shutdown();
-        bStatsMetrics.shutdown();
+        if (bStatsMetrics != null) {
+            bStatsMetrics.shutdown();
+        }
 
         Bukkit.getAsyncScheduler().cancelTasks(this);
         Bukkit.getGlobalRegionScheduler().cancelTasks(this);
@@ -122,7 +124,10 @@ public class Skyllia extends JavaPlugin {
         HookBootstrap.unregisterAll();
 
         if (this.interneAPI != null) {
-            this.interneAPI.getWorldModifier().shutdown();
+            var worldModifier = this.interneAPI.getWorldModifier();
+            if (worldModifier != null) {
+                worldModifier.shutdown();
+            }
             if (this.interneAPI.getDatabaseLoader() != null) {
                 this.interneAPI.getDatabaseLoader().closeDatabase();
             }

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/ForceCreateSubCommands.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/admin/subcommands/ForceCreateSubCommands.java
@@ -88,9 +88,7 @@ public class ForceCreateSubCommands implements SubCommandInterface {
                 return;
             }
 
-            String schemKey = (schemArg != null && schematicsKeys.contains(schemArg))
-                    ? schemArg
-                    : schematicsKeys.getFirst();
+            String schemKey = resolveSchematicKey(schemArg, schematicsKeys);
 
             Map<String, SchematicSetting> schematicSettingMap = IslandUtils.getSchematic(schemKey);
             if (schematicSettingMap == null || schematicSettingMap.isEmpty()) {
@@ -140,6 +138,19 @@ public class ForceCreateSubCommands implements SubCommandInterface {
             logger.log(Level.FATAL, e.getMessage(), e);
             ConfigLoader.language.sendMessage(sender, "island.generic.unexpected-error");
         }
+    }
+
+    private String resolveSchematicKey(String requestedKey, List<String> schematicsKeys) {
+        if (requestedKey != null && schematicsKeys.contains(requestedKey)) {
+            return requestedKey;
+        }
+
+        String defaultSchemKey = ConfigLoader.islandManager.getDefaultIslandKey();
+        if (defaultSchemKey != null && schematicsKeys.contains(defaultSchemKey)) {
+            return defaultSchemKey;
+        }
+
+        return schematicsKeys.getFirst();
     }
 
     private CompletableFuture<Void> pasteAllSchematics(Island island,

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
@@ -64,7 +64,7 @@ public class CreateSubCommand implements SubCommandInterface {
                 return;
             }
 
-            String schemKey = (args.length > 0 && schematicsKeys.contains(args[0])) ? args[0] : schematicsKeys.getFirst();
+            String schemKey = resolveSchematicKey(args.length > 0 ? args[0] : null, schematicsKeys);
             Map<String, SchematicSetting> schematicSettingMap = IslandUtils.getSchematic(schemKey);
             if (schematicSettingMap == null || schematicSettingMap.isEmpty()) {
                 ConfigLoader.language.sendMessage(player, "island.schematic-not-exist");
@@ -116,6 +116,19 @@ public class CreateSubCommand implements SubCommandInterface {
                         CommandCacheExecution.removeCommandExec(playerId, "create");
                     });
         });
+    }
+
+    private String resolveSchematicKey(String requestedKey, List<String> schematicsKeys) {
+        if (requestedKey != null && schematicsKeys.contains(requestedKey)) {
+            return requestedKey;
+        }
+
+        String defaultSchemKey = ConfigLoader.islandManager.getDefaultIslandKey();
+        if (defaultSchemKey != null && schematicsKeys.contains(defaultSchemKey)) {
+            return defaultSchemKey;
+        }
+
+        return schematicsKeys.getFirst();
     }
 
     private CompletableFuture<Void> pasteAllSchematics(Skyllia plugin, Player player, Island island,

--- a/plugin/src/main/resources/config/schematics.toml
+++ b/plugin/src/main/resources/config/schematics.toml
@@ -32,7 +32,7 @@ copy-entities = true
 # Specify the schematic handling plugin: WorldEdit or Internal (WorldEdit and FastAsyncWorldEdit are the same)
 plugin = "WorldEdit"
 
-[my_first_island.sky-end]
+["my_first_island.sky-end"]
 schematic = "./schematics/default.schem"
 height = 64.0
 ignore-air-blocks = true
@@ -41,8 +41,8 @@ copy-entities = true
 plugin = "WorldEdit"
 
 # ───────────────────────────────
-# island: my_second_islands | world: sky-overworld
-["my_second_islands.sky-overworld"]
+# island: my_second_island | world: sky-overworld
+["my_second_island.sky-overworld"]
 schematic = "./schematics/default.schem"
 height = 64.0
 ignore-air-blocks = true
@@ -50,7 +50,7 @@ copy-entities = true
 # Specify the schematic handling plugin: WorldEdit or Internal (WorldEdit and FastAsyncWorldEdit are the same)
 plugin = "WorldEdit"
 
-["my_second_islands.sky-nether"]
+["my_second_island.sky-nether"]
 schematic = "./schematics/default.schem"
 height = 64.0
 ignore-air-blocks = true
@@ -58,7 +58,7 @@ copy-entities = true
 # Specify the schematic handling plugin: WorldEdit or Internal (WorldEdit and FastAsyncWorldEdit are the same)
 plugin = "WorldEdit"
 
-["my_second_islands.sky-end"]
+["my_second_island.sky-end"]
 schematic = "./schematics/default.schem"
 height = 64.0
 ignore-air-blocks = true


### PR DESCRIPTION
This PR fixes a few issues in the default island configuration.

The second default island type was defined as `my_second_island` in `islands.toml`, but its schematic entries were registered under `my_second_islands` in `schematics.toml`. Because island creation resolves settings by the island type key, the second default island type could not resolve correctly.

It also fixes the `my_first_island.sky-end` table to use the same quoted dotted-key format as the other schematic entries. The schematic loader expects top-level keys containing a dot, so `[my_first_island.sky-end]` should be `["my_first_island.sky-end"]`.

Island creation now uses the configured `default-island.default-schem-key` instead of falling back to the first schematic key from the map.

I also added null guards in shutdown paths so early startup failures do not cause extra errors during plugin disable.