### PR TITLE
Fix island creation lifecycle around schematic paste completion

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
@@ -35,49 +35,63 @@ public class CreateSubCommand implements SubCommandInterface {
     private final Logger logger = LogManager.getLogger(CreateSubCommand.class);
 
     public CompletableFuture<Void> runCreateIsland(Skyllia plugin, Player player, String[] args) {
+        final CompletableFuture<Void> result = new CompletableFuture<>();
         final UUID playerId = player.getUniqueId();
         final AtomicBoolean acquired = new AtomicBoolean(false);
 
-        return CompletableFuture.<CompletableFuture<Void>>supplyAsync(() -> {
+        CompletableFuture.runAsync(() -> {
             if (!CommandCacheExecution.tryAcquire(playerId, "create")) {
                 ConfigLoader.language.sendMessage(player, "island.generic.command-in-progress");
-                return CompletableFuture.<Void>completedFuture(null);
+                result.complete(null);
+                return;
             }
             acquired.set(true);
 
             if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create")) {
                 ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             Island existingIsland = SkylliaAPI.getIslandByPlayerId(playerId);
             if (existingIsland != null) {
                 new HomeSubCommand().onExecute(plugin, player, args);
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             List<String> schematicsKeys = ConfigLoader.schematicManager.getIslandTypes();
             if (schematicsKeys.isEmpty()) {
                 ConfigLoader.language.sendMessage(player, "island.schematic-not-exist");
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             String schemKey = resolveSchematicKey(args.length > 0 ? args[0] : null, schematicsKeys);
             Map<String, SchematicSetting> schematicSettingMap = IslandUtils.getSchematic(schemKey);
             if (schematicSettingMap == null || schematicSettingMap.isEmpty()) {
                 ConfigLoader.language.sendMessage(player, "island.schematic-not-exist");
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             IslandSettings islandSettings = IslandUtils.getIslandSettings(schemKey);
             if (islandSettings == null) {
                 ConfigLoader.language.sendMessage(player, "island.type-not-exist");
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create.%s".formatted(schemKey))) {
                 ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             ConfigLoader.language.sendMessage(player, "island.create-in-progress");
@@ -87,36 +101,43 @@ public class CreateSubCommand implements SubCommandInterface {
             boolean isCreate = SkylliaAPI.createIsland(idIsland, islandSettings, owners);
             if (!isCreate) {
                 ConfigLoader.language.sendMessage(player, "island.generic-error");
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             Island island = SkylliaAPI.getIslandByIslandId(idIsland);
             if (island == null) {
                 ConfigLoader.language.sendMessage(player, "island.generic-error");
-                return CompletableFuture.<Void>completedFuture(null);
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+                result.complete(null);
+                return;
             }
 
             new SkyblockCreateEvent(island, playerId).callEvent();
 
-            return pasteAllSchematics(plugin, player, island, schematicSettingMap)
-                    .handle((result, throwable) -> {
+            pasteAllSchematics(plugin, player, island, schematicSettingMap)
+                    .whenComplete((pasteResult, throwable) -> {
                         if (throwable != null) {
                             logger.error("Island creation failed for {}: {}", island.getId(), throwable.getMessage(), throwable);
                             ConfigLoader.language.sendMessage(player, "island.generic-error");
                         } else {
                             ConfigLoader.language.sendMessage(player, "island.create-finish");
                         }
-                        return (Void) null;
+                        CommandCacheExecution.removeCommandExec(playerId, "create");
+                        result.complete(null);
                     });
-        }).thenCompose(future -> future).whenComplete((result, throwable) -> {
-            if (throwable != null) {
-                logger.error("Island creation failed for {}: {}", playerId, throwable.getMessage(), throwable);
-                ConfigLoader.language.sendMessage(player, "island.generic-error");
-            }
+        }).exceptionally(throwable -> {
+            logger.error("Island creation failed for {}: {}", playerId, throwable.getMessage(), throwable);
+            ConfigLoader.language.sendMessage(player, "island.generic-error");
             if (acquired.get()) {
                 CommandCacheExecution.removeCommandExec(playerId, "create");
             }
+            result.complete(null);
+            return null;
         });
+
+        return result;
     }
 
     private String resolveSchematicKey(String requestedKey, List<String> schematicsKeys) {

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
@@ -34,64 +34,53 @@ public class CreateSubCommand implements SubCommandInterface {
 
     private final Logger logger = LogManager.getLogger(CreateSubCommand.class);
 
+    private record IslandCreationContext(Island island, Map<String, SchematicSetting> schematicSettingMap) {
+    }
+
     public CompletableFuture<Void> runCreateIsland(Skyllia plugin, Player player, String[] args) {
-        final CompletableFuture<Void> result = new CompletableFuture<>();
         final UUID playerId = player.getUniqueId();
         final AtomicBoolean acquired = new AtomicBoolean(false);
 
-        CompletableFuture.runAsync(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             if (!CommandCacheExecution.tryAcquire(playerId, "create")) {
                 ConfigLoader.language.sendMessage(player, "island.generic.command-in-progress");
-                result.complete(null);
-                return;
+                return null;
             }
             acquired.set(true);
 
             if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create")) {
                 ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             Island existingIsland = SkylliaAPI.getIslandByPlayerId(playerId);
             if (existingIsland != null) {
                 new HomeSubCommand().onExecute(plugin, player, args);
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             List<String> schematicsKeys = ConfigLoader.schematicManager.getIslandTypes();
             if (schematicsKeys.isEmpty()) {
                 ConfigLoader.language.sendMessage(player, "island.schematic-not-exist");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             String schemKey = resolveSchematicKey(args.length > 0 ? args[0] : null, schematicsKeys);
             Map<String, SchematicSetting> schematicSettingMap = IslandUtils.getSchematic(schemKey);
             if (schematicSettingMap == null || schematicSettingMap.isEmpty()) {
                 ConfigLoader.language.sendMessage(player, "island.schematic-not-exist");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             IslandSettings islandSettings = IslandUtils.getIslandSettings(schemKey);
             if (islandSettings == null) {
                 ConfigLoader.language.sendMessage(player, "island.type-not-exist");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create.%s".formatted(schemKey))) {
                 ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             ConfigLoader.language.sendMessage(player, "island.create-in-progress");
@@ -101,43 +90,42 @@ public class CreateSubCommand implements SubCommandInterface {
             boolean isCreate = SkylliaAPI.createIsland(idIsland, islandSettings, owners);
             if (!isCreate) {
                 ConfigLoader.language.sendMessage(player, "island.generic-error");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             Island island = SkylliaAPI.getIslandByIslandId(idIsland);
             if (island == null) {
                 ConfigLoader.language.sendMessage(player, "island.generic-error");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                result.complete(null);
-                return;
+                return null;
             }
 
             new SkyblockCreateEvent(island, playerId).callEvent();
 
-            pasteAllSchematics(plugin, player, island, schematicSettingMap)
-                    .whenComplete((pasteResult, throwable) -> {
+            return new IslandCreationContext(island, schematicSettingMap);
+        }).thenCompose(context -> {
+            if (context == null) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            return pasteAllSchematics(plugin, player, context.island(), context.schematicSettingMap())
+                    .handle((result, throwable) -> {
                         if (throwable != null) {
-                            logger.error("Island creation failed for {}: {}", island.getId(), throwable.getMessage(), throwable);
+                            logger.error("Island creation failed for {}: {}", context.island().getId(), throwable.getMessage(), throwable);
                             ConfigLoader.language.sendMessage(player, "island.generic-error");
                         } else {
                             ConfigLoader.language.sendMessage(player, "island.create-finish");
                         }
-                        CommandCacheExecution.removeCommandExec(playerId, "create");
-                        result.complete(null);
+                        return (Void) null;
                     });
         }).exceptionally(throwable -> {
             logger.error("Island creation failed for {}: {}", playerId, throwable.getMessage(), throwable);
             ConfigLoader.language.sendMessage(player, "island.generic-error");
+            return null;
+        }).whenComplete((result, throwable) -> {
             if (acquired.get()) {
                 CommandCacheExecution.removeCommandExec(playerId, "create");
             }
-            result.complete(null);
-            return null;
         });
-
-        return result;
     }
 
     private String resolveSchematicKey(String requestedKey, List<String> schematicsKeys) {
@@ -174,10 +162,10 @@ public class CreateSubCommand implements SubCommandInterface {
                 return Skyllia.getInstance().getInterneAPI()
                         .getSchematicHook(SchematicPlugin.fromString(setting.plugin()))
                         .paste(center, setting)
-                        .thenAcceptAsync(success -> {
+                        .thenComposeAsync(success -> {
                             if (!success) {
                                 island.setDisable(true);
-                                throw new RuntimeException("Schematic paste failed for world " + worldName);
+                                return CompletableFuture.failedFuture(new RuntimeException("Schematic paste failed for world " + worldName));
                             }
                             if (setting.minBuildHeight() != null) {
                                 island.setBuildHeight(worldName, HeightType.MIN, setting.minBuildHeight());
@@ -193,30 +181,42 @@ public class CreateSubCommand implements SubCommandInterface {
                                         .cacheIslandAndIndex(island);
 
                                 new SkyblockLoadEvent(island).callEvent();
-                                Location spawnLoc = center.clone().add(0, 0.5, 0);
-                                player.teleportAsync(spawnLoc, PlayerTeleportEvent.TeleportCause.PLUGIN)
-                                        .thenAccept(successTeleport -> {
-                                            if (!successTeleport) {
-                                                return;
-                                            }
-                                            player.getScheduler().run(plugin, task -> {
-                                                player.setVelocity(new Vector(0, 0, 0));
-                                                player.setFallDistance(0);
-                                                if (PlayerUtils.hasPermission(player, "skyllia.island.worldborder.bypass")) {
-                                                    return;
-                                                }
-                                                WorldBorder border = player.getWorldBorder();
-                                                if (border == null) border = Bukkit.createWorldBorder();
-                                                border.setCenter(center);
-                                                border.setSize(island.getSize());
-                                                player.setWorldBorder(border);
-                                            }, null);
-                                        });
+                                return teleportAndApplyBorder(plugin, player, island, center);
                             }
+                            return CompletableFuture.completedFuture(null);
                         });
             });
         }
         return chain;
+    }
+
+    private CompletableFuture<Void> teleportAndApplyBorder(Skyllia plugin, Player player, Island island, Location center) {
+        Location spawnLoc = center.clone().add(0, 0.5, 0);
+        return player.teleportAsync(spawnLoc, PlayerTeleportEvent.TeleportCause.PLUGIN)
+                .thenCompose(successTeleport -> {
+                    if (!successTeleport) {
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    CompletableFuture<Void> playerUpdate = new CompletableFuture<>();
+                    player.getScheduler().run(plugin, task -> {
+                        try {
+                            player.setVelocity(new Vector(0, 0, 0));
+                            player.setFallDistance(0);
+                            if (!PlayerUtils.hasPermission(player, "skyllia.island.worldborder.bypass")) {
+                                WorldBorder border = player.getWorldBorder();
+                                if (border == null) border = Bukkit.createWorldBorder();
+                                border.setCenter(center);
+                                border.setSize(island.getSize());
+                                player.setWorldBorder(border);
+                            }
+                            playerUpdate.complete(null);
+                        } catch (Throwable throwable) {
+                            playerUpdate.completeExceptionally(throwable);
+                        }
+                    }, () -> playerUpdate.complete(null));
+                    return playerUpdate;
+                });
     }
 
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
@@ -181,7 +181,7 @@ public class CreateSubCommand implements SubCommandInterface {
                                         .cacheIslandAndIndex(island);
 
                                 new SkyblockLoadEvent(island).callEvent();
-                                return teleportAndApplyBorder(plugin, player, island, center);
+                                return teleportAndApplyBorder(player, island, center);
                             }
                             return CompletableFuture.completedFuture(null);
                         });
@@ -190,32 +190,23 @@ public class CreateSubCommand implements SubCommandInterface {
         return chain;
     }
 
-    private CompletableFuture<Void> teleportAndApplyBorder(Skyllia plugin, Player player, Island island, Location center) {
+    private CompletableFuture<Void> teleportAndApplyBorder(Player player, Island island, Location center) {
         Location spawnLoc = center.clone().add(0, 0.5, 0);
         return player.teleportAsync(spawnLoc, PlayerTeleportEvent.TeleportCause.PLUGIN)
-                .thenCompose(successTeleport -> {
+                .thenAccept(successTeleport -> {
                     if (!successTeleport) {
-                        return CompletableFuture.completedFuture(null);
+                        return;
                     }
-
-                    CompletableFuture<Void> playerUpdate = new CompletableFuture<>();
-                    player.getScheduler().run(plugin, task -> {
-                        try {
-                            player.setVelocity(new Vector(0, 0, 0));
-                            player.setFallDistance(0);
-                            if (!PlayerUtils.hasPermission(player, "skyllia.island.worldborder.bypass")) {
-                                WorldBorder border = player.getWorldBorder();
-                                if (border == null) border = Bukkit.createWorldBorder();
-                                border.setCenter(center);
-                                border.setSize(island.getSize());
-                                player.setWorldBorder(border);
-                            }
-                            playerUpdate.complete(null);
-                        } catch (Throwable throwable) {
-                            playerUpdate.completeExceptionally(throwable);
-                        }
-                    }, () -> playerUpdate.complete(null));
-                    return playerUpdate;
+                    player.setVelocity(new Vector(0, 0, 0));
+                    player.setFallDistance(0);
+                    if (PlayerUtils.hasPermission(player, "skyllia.island.worldborder.bypass")) {
+                        return;
+                    }
+                    WorldBorder border = player.getWorldBorder();
+                    if (border == null) border = Bukkit.createWorldBorder();
+                    border.setCenter(center);
+                    border.setSize(island.getSize());
+                    player.setWorldBorder(border);
                 });
     }
 

--- a/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/commands/common/subcommands/CreateSubCommand.java
@@ -35,54 +35,49 @@ public class CreateSubCommand implements SubCommandInterface {
     private final Logger logger = LogManager.getLogger(CreateSubCommand.class);
 
     public CompletableFuture<Void> runCreateIsland(Skyllia plugin, Player player, String[] args) {
-        return CompletableFuture.runAsync(() -> {
+        final UUID playerId = player.getUniqueId();
+        final AtomicBoolean acquired = new AtomicBoolean(false);
 
-            final UUID playerId = player.getUniqueId();
-
+        return CompletableFuture.<CompletableFuture<Void>>supplyAsync(() -> {
             if (!CommandCacheExecution.tryAcquire(playerId, "create")) {
                 ConfigLoader.language.sendMessage(player, "island.generic.command-in-progress");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
+            acquired.set(true);
 
             if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create")) {
                 ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             Island existingIsland = SkylliaAPI.getIslandByPlayerId(playerId);
             if (existingIsland != null) {
                 new HomeSubCommand().onExecute(plugin, player, args);
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             List<String> schematicsKeys = ConfigLoader.schematicManager.getIslandTypes();
             if (schematicsKeys.isEmpty()) {
                 ConfigLoader.language.sendMessage(player, "island.schematic-not-exist");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             String schemKey = resolveSchematicKey(args.length > 0 ? args[0] : null, schematicsKeys);
             Map<String, SchematicSetting> schematicSettingMap = IslandUtils.getSchematic(schemKey);
             if (schematicSettingMap == null || schematicSettingMap.isEmpty()) {
                 ConfigLoader.language.sendMessage(player, "island.schematic-not-exist");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             IslandSettings islandSettings = IslandUtils.getIslandSettings(schemKey);
             if (islandSettings == null) {
                 ConfigLoader.language.sendMessage(player, "island.type-not-exist");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             if (!PlayerUtils.hasPermission(player, "skyllia.island.command.create.%s".formatted(schemKey))) {
                 ConfigLoader.language.sendMessage(player, "island.player.permission-denied");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             ConfigLoader.language.sendMessage(player, "island.create-in-progress");
@@ -92,29 +87,35 @@ public class CreateSubCommand implements SubCommandInterface {
             boolean isCreate = SkylliaAPI.createIsland(idIsland, islandSettings, owners);
             if (!isCreate) {
                 ConfigLoader.language.sendMessage(player, "island.generic-error");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             Island island = SkylliaAPI.getIslandByIslandId(idIsland);
             if (island == null) {
                 ConfigLoader.language.sendMessage(player, "island.generic-error");
-                CommandCacheExecution.removeCommandExec(playerId, "create");
-                return;
+                return CompletableFuture.<Void>completedFuture(null);
             }
 
             new SkyblockCreateEvent(island, playerId).callEvent();
 
-            pasteAllSchematics(plugin, player, island, schematicSettingMap)
-                    .whenComplete((result, throwable) -> {
+            return pasteAllSchematics(plugin, player, island, schematicSettingMap)
+                    .handle((result, throwable) -> {
                         if (throwable != null) {
-                            logger.error("Island creation failed for {}: {}", island.getId(), throwable.getMessage());
+                            logger.error("Island creation failed for {}: {}", island.getId(), throwable.getMessage(), throwable);
                             ConfigLoader.language.sendMessage(player, "island.generic-error");
                         } else {
                             ConfigLoader.language.sendMessage(player, "island.create-finish");
                         }
-                        CommandCacheExecution.removeCommandExec(playerId, "create");
+                        return (Void) null;
                     });
+        }).thenCompose(future -> future).whenComplete((result, throwable) -> {
+            if (throwable != null) {
+                logger.error("Island creation failed for {}: {}", playerId, throwable.getMessage(), throwable);
+                ConfigLoader.language.sendMessage(player, "island.generic-error");
+            }
+            if (acquired.get()) {
+                CommandCacheExecution.removeCommandExec(playerId, "create");
+            }
         });
     }
 
@@ -173,17 +174,22 @@ public class CreateSubCommand implements SubCommandInterface {
                                 new SkyblockLoadEvent(island).callEvent();
                                 Location spawnLoc = center.clone().add(0, 0.5, 0);
                                 player.teleportAsync(spawnLoc, PlayerTeleportEvent.TeleportCause.PLUGIN)
-                                        .thenRun(() -> {
-                                            player.setVelocity(new Vector(0, 0, 0));
-                                            player.setFallDistance(0);
-                                            if (PlayerUtils.hasPermission(player, "skyllia.island.worldborder.bypass")) {
+                                        .thenAccept(successTeleport -> {
+                                            if (!successTeleport) {
                                                 return;
                                             }
-                                            WorldBorder border = player.getWorldBorder();
-                                            if (border == null) border = Bukkit.createWorldBorder();
-                                            border.setCenter(center);
-                                            border.setSize(island.getSize());
-                                            player.setWorldBorder(border);
+                                            player.getScheduler().run(plugin, task -> {
+                                                player.setVelocity(new Vector(0, 0, 0));
+                                                player.setFallDistance(0);
+                                                if (PlayerUtils.hasPermission(player, "skyllia.island.worldborder.bypass")) {
+                                                    return;
+                                                }
+                                                WorldBorder border = player.getWorldBorder();
+                                                if (border == null) border = Bukkit.createWorldBorder();
+                                                border.setCenter(center);
+                                                border.setSize(island.getSize());
+                                                player.setWorldBorder(border);
+                                            }, null);
                                         });
                             }
                         });


### PR DESCRIPTION
## What changed

The island creation flow now chains the schematic paste future into the future returned by `runCreateIsland()`.

This prevents the creation queue from moving to the next request before the previous island paste work has completed.

Post-teleport player updates are also scheduled through the player scheduler after teleport completion.

## Why

The queue uses the returned future to decide when the next island creation can start. If the paste future is started but not returned, the queue can continue too early.

The changes keep the existing creation flow and schematic hook selection intact.