### PR TITLE
Fix : Piston Head can get out the island

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/bukkitevents/blocks/PistonEvent.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/bukkitevents/blocks/PistonEvent.java
@@ -43,13 +43,27 @@ public class PistonEvent implements Listener {
             return;
         }
         int[] offset = OFFSETS[event.getDirection().ordinal()];
+
+        Block piston = event.getBlock();
+        Location headLocation = piston.getLocation().add(offset[0], offset[1], offset[2]);
+        int headX = headLocation.getBlockX();
+        int headZ = headLocation.getBlockZ();
+        Island island = ListenersUtils.checkChunkIsIsland(headX >> 4, headZ >> 4, event);
+        if (island == null) {
+            return;
+        }
+        ListenersUtils.isBlockOutsideIsland(island, world, headX, headLocation.getBlockY(), headZ, event);
+        if (event.isCancelled()) {
+            return;
+        }
+
         for (Block block : event.getBlocks()) {
             Location location = block.getLocation().add(offset[0], offset[1], offset[2]);
             int blockX = location.getBlockX();
             int blockZ = location.getBlockZ();
             int chunkX = blockX >> 4;
             int chunkZ = blockZ >> 4;
-            Island island = ListenersUtils.checkChunkIsIsland(chunkX, chunkZ, event);
+            island = ListenersUtils.checkChunkIsIsland(chunkX, chunkZ, event);
             if (island == null) {
                 return;
             }


### PR DESCRIPTION
Close : #167 

<img width="939" height="545" alt="image" src="https://github.com/user-attachments/assets/8f69a458-5cba-485e-b78a-3054fca9ec6a" />


**Before (broken)**: A piston at the island edge extending outward pushes its head outside the island, because event.getBlocks() was empty and no boundary check ran.


**Now (fixed)**: Before checking pushed blocks, the code calculates where the piston head would appear (piston location + direction). If that block's chunk has no island, or the head position is outside the island's bounds, the event is cancelled immediately : the piston stays blocked.

Closes #167 