### PR TITLE
Fix : Gravity blocks (Sand, Gravel) can be placed, if there is a valid block, even outside of an island. (#169)

### DIFF
--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/ListenersRegistrar.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/ListenersRegistrar.java
@@ -3,6 +3,7 @@ package fr.euphyllia.skyllia.listeners;
 import fr.euphyllia.skyllia.Skyllia;
 import fr.euphyllia.skyllia.api.InterneAPI;
 import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.listeners.bukkitevents.blocks.FallingBlockEvent;
 import fr.euphyllia.skyllia.listeners.bukkitevents.blocks.GrowEvent;
 import fr.euphyllia.skyllia.listeners.bukkitevents.blocks.PistonEvent;
 import fr.euphyllia.skyllia.listeners.bukkitevents.paper.PortalAlternativePaperEvent;
@@ -89,6 +90,7 @@ public class ListenersRegistrar {
         registerEvent(pluginManager, new WorldBorderAddEvent(interneAPI));
         registerEvent(pluginManager, new PistonEvent(interneAPI));
         registerEvent(pluginManager, new GrowEvent(interneAPI));
+        registerEvent(pluginManager, new FallingBlockEvent());
         registerEvent(pluginManager, new MoveEvent());
         registerEvent(pluginManager, new QuitEvent());
         registerEvent(pluginManager, new RespawnEvent(interneAPI));

--- a/plugin/src/main/java/fr/euphyllia/skyllia/listeners/bukkitevents/blocks/FallingBlockEvent.java
+++ b/plugin/src/main/java/fr/euphyllia/skyllia/listeners/bukkitevents/blocks/FallingBlockEvent.java
@@ -1,0 +1,39 @@
+package fr.euphyllia.skyllia.listeners.bukkitevents.blocks;
+
+import fr.euphyllia.skyllia.api.SkylliaAPI;
+import fr.euphyllia.skyllia.api.skyblock.Island;
+import fr.euphyllia.skyllia.listeners.ListenersUtils;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
+
+public class FallingBlockEvent implements Listener {
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onFallingBlockLand(final EntityChangeBlockEvent event) {
+        if (!(event.getEntity() instanceof FallingBlock)) return;
+
+        World world = event.getBlock().getWorld();
+        if (!SkylliaAPI.isWorldSkyblock(world.getName())) return;
+
+        Location loc = event.getBlock().getLocation();
+        int bx = loc.getBlockX();
+        int bz = loc.getBlockZ();
+
+        Island island = SkylliaAPI.getIslandByChunk(bx >> 4, bz >> 4);
+        if (island == null) {
+            event.setCancelled(true);
+            event.getEntity().remove();
+            return;
+        }
+
+        ListenersUtils.isBlockOutsideIsland(island, world, bx, loc.getBlockY(), bz, event);
+        if (event.isCancelled()) {
+            event.getEntity().remove();
+        }
+    }
+}


### PR DESCRIPTION
**The bug**: Gravity blocks (sand, gravel, concrete powder, anvils, dragon eggs, scaffolding) could fall and land in areas outside of player islands : either in unclaimed chunks or beyond the island's build boundaries — effectively littering or griefing non-island territory.

**The fix**: A new event listener (`FallingBlockEvent.java`) intercepts `EntityChangeBlockEvent`, the event fired when a FallingBlock entity lands and turns into a solid block. The handler:

1. Checks that the entity is a FallingBlock (skip non-gravity entities).
2. Verifies the world is a registered skyblock world (skip vanilla worlds).
3. Resolves the island at the landing position via chunk-to-region lookup (`SkylliaAPI.getIslandByChunk`).
4. If no island owns this chunk : cancels the event and removes the entity (block never places).
5. If an island exists but the landing coordinates are outside its bounds (`island.isInside()`),  same: event cancelled, entity removed.

> This prevents any gravity block from ever solidifying outside a player's island while letting them behave normally inside island bounds.

> Note : The method used in the bug destroys the sand entity when it falls onto a block outside the island, causing the sand block to disappear; this isn't necessarily a major issue, given that a block outside the island isn't supposed to be retrievable anyway.

Closes #169 